### PR TITLE
Freeing tx before unreferencing a net buffer after failed buffer send.

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -728,6 +728,10 @@ void bt_conn_process_tx(struct bt_conn *conn)
 	buf = net_buf_get(&conn->tx_queue, K_NO_WAIT);
 	BT_ASSERT(buf);
 	if (!send_buf(conn, buf)) {
+		if (tx_data(buf)->tx) {
+                	tx_free(tx_data(buf)->tx);
+            	}
+
 		net_buf_unref(buf);
 	}
 }


### PR DESCRIPTION
With frequent disconnects and reconnects to a single peer device while simultaneously writing to a peer device GATT characteristic, the BLE central device will typically freeze.  This is due to the number of available connection tx objects running out.  
 When the buffer fails to send, the buffer may be unreferenced without the tx pointer being re-added to the available pool. 
 Therefore, this fix is proposed, which emulates the behavior of `conn_cleanup()`.    

The effect can be mitigated by increasing `CONFIG_BT_CONN_TX_MAX`, however choosing a "magic number" for a parameter is not an ideal or permanent solution.