### PR TITLE
Zephyr v2.7.0 Fix issues with sudden disconnects and high write speeds.

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1685,16 +1685,17 @@ void ull_conn_tx_ack(uint16_t handle, memq_link_t *link, struct node_tx *tx)
 		}
 
 		/* release ctrl mem if points to itself */
-		if (link->next == (void *)tx) {
-			LL_ASSERT(link->next);
+		if (tx) {
+			/* release ctrl mem if points to itself */
+			if (link->next == (void *)tx) {
+				LL_ASSERT(link->next);
 
-			mem_release(tx, &mem_conn_tx_ctrl.free);
-			return;
-		} else if (!tx) {
+				mem_release(tx, &mem_conn_tx_ctrl.free);
+				return;
+			}
+		} else {
 			/* Tx Node re-used to enqueue new ctrl PDU */
 			return;
-		} else {
-			//LL_ASSERT(!link->next);
 		}
 	} else if (handle == LLL_HANDLE_INVALID) {
 		pdu_tx->ll_id = PDU_DATA_LLID_RESV;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1694,7 +1694,7 @@ void ull_conn_tx_ack(uint16_t handle, memq_link_t *link, struct node_tx *tx)
 			/* Tx Node re-used to enqueue new ctrl PDU */
 			return;
 		} else {
-			LL_ASSERT(!link->next);
+			//LL_ASSERT(!link->next);
 		}
 	} else if (handle == LLL_HANDLE_INVALID) {
 		pdu_tx->ll_id = PDU_DATA_LLID_RESV;

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -184,6 +184,10 @@ static void tx_notify(struct bt_conn *conn)
 		/* Free up TX notify since there may be user waiting */
 		tx_free(tx);
 
+		if (cb == NULL) {
+			break;
+		}
+
 		/* Run the callback, at this point it should be safe to
 		 * allocate new buffers since the TX should have been
 		 * unblocked by tx_free.

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -184,15 +184,13 @@ static void tx_notify(struct bt_conn *conn)
 		/* Free up TX notify since there may be user waiting */
 		tx_free(tx);
 
-		if (cb == NULL) {
-			break;
-		}
-
 		/* Run the callback, at this point it should be safe to
 		 * allocate new buffers since the TX should have been
 		 * unblocked by tx_free.
 		 */
-		cb(conn, user_data);
+		if (cb) {
+		    cb(conn, user_data);
+		}
 	}
 }
 


### PR DESCRIPTION
In case of a sudden disconnect, the `cb()` function pointer can be NULL, leading to an "illegal use of the EPSR" kernel fault.  The other change is to remove an assertion that could potentially trigger (also) in the case of a sudden disconnect.