### PR TITLE
DECO-95 - Immediate logging for filesystem backend support

### DIFF
--- a/subsys/logging/log_backend_fs.c
+++ b/subsys/logging/log_backend_fs.c
@@ -426,7 +426,7 @@ static int del_oldest_log(void)
 	return rc;
 }
 
-BUILD_ASSERT(!IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE),
+BUILD_ASSERT(!IS_ENABLED(CONFIG_LOG1_IMMEDIATE),
 	     "Immediate logging is not supported by LOG FS backend.");
 
 #ifndef CONFIG_LOG_BACKEND_FS_TESTSUITE


### PR DESCRIPTION
In the original code the `CONFIG_LOG_MODE_IMMEDIATE` configuration could not be set in conjunction with the use of the filesystem backend logger through `CONFIG_LOG_BACKEND_FS`. It claimed not to support the immediate logging functionality. Nevertheless, all the functions needed for logging V2 are correctly implemented. The missing functions in this backend are for logging V1. Therefore, the assert statement in the code is changed to check on the configuration parameter `CONFIG_LOG1_IMMEDIATE` such that the immediate logging option can be enabled when logging V2 is used.