### PR TITLE
DECO-79 - Flash memory

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -16,6 +16,8 @@
 #include <zephyr/drivers/flash.h>
 #include <soc.h>
 
+#include <SEGGER_RTT.h>
+
 /* Buffer is only needed for bytes that follow command and offset */
 #define BUF_ARRAY_CNT (CONFIG_SHELL_ARGC_MAX - 2)
 #define TEST_ARR_SIZE 0x1000
@@ -175,6 +177,77 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_write_rtt(const struct shell *shell, size_t argc, char *argv[])
+{
+	uint32_t __aligned(4) read_array[BUF_ARRAY_CNT];
+	uint32_t __aligned(4) buf_array[BUF_ARRAY_CNT];
+	const struct device *flash_dev;
+	uint32_t w_addr;
+	int ret;
+	size_t op_size = 0;
+	int rtt_channel = 0;
+	size_t data_per_chunk = 0;
+	size_t data_to_read = 0;
+	size_t data_size = 0;
+	size_t data_received = 0;
+	int write_error = 0;
+
+	ret = parse_helper(shell, &argc, &argv, &flash_dev, &w_addr);
+	if (ret) {
+		return ret;
+	}
+
+	data_per_chunk = strtoul(argv[2], NULL, 16);
+	if (data_per_chunk >= sizeof(buf_array)) {
+		shell_error(shell, "ERROR: buffer size too big");
+		return -EDOM;
+	}
+
+	data_size = strtoul(argv[3], NULL, 16);
+
+	rtt_channel = SEGGER_RTT_AllocDownBuffer("Shell flash write", buf_array, sizeof(buf_array), 0);
+	if (rtt_channel < 0) {
+		shell_error(shell, "ERROR: could not create RTT channel");
+		return -1;
+	} else {
+		shell_print(shell, "RTT channel %d", rtt_channel);
+	}
+
+	data_to_read = data_per_chunk;
+	while (data_received < data_size) {
+		if (SEGGER_RTT_HasData(rtt_channel)) {
+			if (data_size - data_received < data_per_chunk) {
+				data_to_read = data_size - data_received;
+			}
+			op_size = 0;
+			do {
+				op_size = SEGGER_RTT_Read(rtt_channel, read_array + op_size, data_to_read - op_size);
+			} while(op_size != data_to_read);
+			if (flash_write(flash_dev, w_addr, read_array, op_size) != 0) {
+				shell_error(shell, "Write internal ERROR!");
+				write_error = 1;
+				break;
+			} else {
+				shell_print(shell, "Write OK.");
+			}
+			w_addr += op_size;
+			data_received += op_size;
+		}
+		k_msleep(5);
+	}
+
+	ret = SEGGER_RTT_ConfigDownBuffer(rtt_channel, "", NULL, 0, 0);
+	if (write_error) {
+		return -EIO;
+	}
+	if (ret < 0) {
+		shell_error(shell, "ERROR: could not destroy RTT channel");
+		return -1;
+	}
+
+	return 0;
+}
+
 static int cmd_read(const struct shell *shell, size_t argc, char *argv[])
 {
 	const struct device *flash_dev;
@@ -294,6 +367,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(flash_cmds,
 	SHELL_CMD_ARG(write, &dsub_device_name,
 		"[<device>] <address> [-v] <dword> [<dword>...]",
 		cmd_write, 3, BUF_ARRAY_CNT),
+	SHELL_CMD_ARG(write_rtt, &dsub_device_name,
+		"[<device>] <address> <buffer_size> <data_size>",
+		cmd_write_rtt, 5, 0),
 	SHELL_SUBCMD_SET_END
 );
 

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -16,7 +16,9 @@
 #include <zephyr/drivers/flash.h>
 #include <soc.h>
 
+#if IS_ENABLED(CONFIG_SHELL_BACKEND_RTT)
 #include <SEGGER_RTT.h>
+#endif
 
 /* Buffer is only needed for bytes that follow command and offset */
 #define BUF_ARRAY_CNT (CONFIG_SHELL_ARGC_MAX - 2)
@@ -177,6 +179,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
+#if IS_ENABLED(CONFIG_SHELL_BACKEND_RTT)
 static int cmd_write_rtt(const struct shell *shell, size_t argc, char *argv[])
 {
 	uint32_t __aligned(4) read_array[BUF_ARRAY_CNT];
@@ -247,6 +250,7 @@ static int cmd_write_rtt(const struct shell *shell, size_t argc, char *argv[])
 
 	return 0;
 }
+#endif
 
 static int cmd_read(const struct shell *shell, size_t argc, char *argv[])
 {
@@ -367,9 +371,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(flash_cmds,
 	SHELL_CMD_ARG(write, &dsub_device_name,
 		"[<device>] <address> [-v] <dword> [<dword>...]",
 		cmd_write, 3, BUF_ARRAY_CNT),
+#if IS_ENABLED(CONFIG_SHELL_BACKEND_RTT)
 	SHELL_CMD_ARG(write_rtt, &dsub_device_name,
 		"[<device>] <address> <buffer_size> <data_size>",
 		cmd_write_rtt, 5, 0),
+#endif
 	SHELL_SUBCMD_SET_END
 );
 

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -120,24 +120,30 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 	uint32_t w_addr;
 	int ret;
 	size_t op_size;
+	int verify = 0;
+	int argstart = 2;
 
 	ret = parse_helper(shell, &argc, &argv, &flash_dev, &w_addr);
 	if (ret) {
 		return ret;
 	}
 
-	if (argc <= 2) {
+	if (strcmp(argv[2], "-v") == 0) {
+		argstart++;
+		verify = 1;
+	}
+
+	if (argc <= argstart) {
 		shell_error(shell, "Missing data to be written.");
 		return -EINVAL;
 	}
 
 	op_size = 0;
 
-	for (int i = 2; i < argc; i++) {
-		int j = i - 2;
+	for (int i = argstart; i < argc; i++) {
+		int j = i - argstart;
 
 		buf_array[j] = strtoul(argv[i], NULL, 16);
-		check_array[j] = ~buf_array[j];
 
 		op_size += sizeof(buf_array[0]);
 	}
@@ -149,16 +155,21 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 
 	shell_print(shell, "Write OK.");
 
-	if (flash_read(flash_dev, w_addr, check_array, op_size) < 0) {
-		shell_print(shell, "Verification read ERROR!");
-		return -EIO;
-	}
+	if (verify == 1) {
+		for (int i = 0; i < argc - argstart; i++) {
+			check_array[i] = ~buf_array[i];
+		}
+		if (flash_read(flash_dev, w_addr, check_array, op_size) < 0) {
+			shell_print(shell, "Verification read ERROR!");
+			return -EIO;
+		}
 
-	if (memcmp(buf_array, check_array, op_size) == 0) {
-		shell_print(shell, "Verified.");
-	} else {
-		shell_error(shell, "Verification ERROR!");
-		return -EIO;
+		if (memcmp(buf_array, check_array, op_size) == 0) {
+			shell_print(shell, "Verified.");
+		} else {
+			shell_error(shell, "Verification ERROR!");
+			return -EIO;
+		}
 	}
 
 	return 0;
@@ -281,7 +292,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(flash_cmds,
 		"[<device>] <address> <size> <repeat count>",
 		cmd_test, 4, 1),
 	SHELL_CMD_ARG(write, &dsub_device_name,
-		"[<device>] <address> <dword> [<dword>...]",
+		"[<device>] <address> [-v] <dword> [<dword>...]",
 		cmd_write, 3, BUF_ARRAY_CNT),
 	SHELL_SUBCMD_SET_END
 );

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -94,9 +94,9 @@ struct flash_stm32_qspi_data {
 	enum jesd216_dw15_qer_type qer_type;
 	enum jesd216_mode_type desired_mode;
 	enum jesd216_mode_type mode;
+	enum jesd216_mode_type qspi_write_mode;
 	int cmd_status;
 	struct stream dma;
-	uint8_t qspi_write_cmd;
 	uint8_t qspi_read_cmd;
 	uint8_t qspi_read_cmd_latency;
 	/*
@@ -156,14 +156,28 @@ static inline int qspi_prepare_quad_program(const struct device *dev,
 {
 	struct flash_stm32_qspi_data *dev_data = dev->data;
 
-	__ASSERT_NO_MSG(dev_data->qspi_write_cmd == SPI_NOR_CMD_PP_1_1_4 ||
-			dev_data->qspi_write_cmd == SPI_NOR_CMD_PP_1_4_4);
+	__ASSERT_NO_MSG(dev_data->qspi_write_mode == JESD216_MODE_111 ||
+			dev_data->qspi_write_mode == JESD216_MODE_114 ||
+			dev_data->qspi_write_mode == JESD216_MODE_144);
 
-	cmd->Instruction = dev_data->qspi_write_cmd;
-	cmd->AddressMode = ((cmd->Instruction == SPI_NOR_CMD_PP_1_1_4)
-				? QSPI_ADDRESS_1_LINE
-				: QSPI_ADDRESS_4_LINES);
-	cmd->DataMode = QSPI_DATA_4_LINES;
+	switch (dev_data->qspi_write_mode) {
+		case JESD216_MODE_111:
+			cmd->Instruction = SPI_NOR_CMD_PP;
+			cmd->AddressMode = QSPI_ADDRESS_1_LINE;
+			cmd->DataMode = QSPI_DATA_1_LINE;
+		case JESD216_MODE_114:
+			cmd->Instruction = SPI_NOR_CMD_PP_1_1_4;
+			cmd->AddressMode = QSPI_ADDRESS_1_LINE;
+			cmd->DataMode = QSPI_DATA_4_LINES;
+			break;
+		case JESD216_MODE_144:
+			cmd->Instruction = SPI_NOR_CMD_PP_1_4_4;
+			cmd->AddressMode = QSPI_ADDRESS_4_LINES;
+			cmd->DataMode = QSPI_DATA_4_LINES;
+			break;
+		default:
+			return -1;
+	}
 	cmd->DummyCycles = 0;
 
 	return 0;
@@ -1276,7 +1290,7 @@ static void flash_stm32_qspi_irq_config_func(const struct device *dev);
 
 #define DT_WRITEOC_PROP_OR(inst, default_value)                                              \
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, writeoc),                                    \
-		    (_CONCAT(SPI_NOR_CMD_, DT_STRING_TOKEN(DT_DRV_INST(inst), writeoc))),    \
+		    (_CONCAT(JESD216_, DT_STRING_TOKEN(DT_DRV_INST(inst), writeoc))),    \
 		    ((default_value)))
 
 #define DT_READOC_PROP_OR(inst, default_value)                                              \
@@ -1320,7 +1334,7 @@ static struct flash_stm32_qspi_data flash_stm32_qspi_dev_data = {
 			},
 	},
 	.qer_type = DT_QER_PROP_OR(0, JESD216_DW15_QER_VAL_S1B6),
-	.qspi_write_cmd = DT_WRITEOC_PROP_OR(0, SPI_NOR_CMD_PP_1_4_4),
+	.qspi_write_mode = DT_WRITEOC_PROP_OR(0, JESD216_MODE_111),
 	.desired_mode = DT_READOC_PROP_OR(0, STM32_QSPI_UNKNOWN_MODE),
 	QSPI_DMA_CHANNEL(STM32_QSPI_NODE, tx_rx)
 };

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -978,7 +978,7 @@ static int spi_nor_process_bfp(const struct device *dev,
 	 */
 	if (IS_ENABLED(STM32_QSPI_USE_QUAD_IO)) {
 		enum jesd216_mode_type supported_modes[] = { JESD216_MODE_114,
-								   JESD216_MODE_144 };
+							 JESD216_MODE_144 };
 		int nr_of_modes = ARRAY_SIZE(supported_modes);
 		if (data->desired_mode != STM32_QSPI_UNKNOWN_MODE) {
 			supported_modes[0] = data->desired_mode;

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -92,6 +92,7 @@ struct flash_stm32_qspi_data {
 	/* Number of bytes per page */
 	uint16_t page_size;
 	enum jesd216_dw15_qer_type qer_type;
+	enum jesd216_mode_type desired_mode;
 	enum jesd216_mode_type mode;
 	int cmd_status;
 	struct stream dma;
@@ -976,16 +977,21 @@ static int spi_nor_process_bfp(const struct device *dev,
 	 * is supported - other modes are not.
 	 */
 	if (IS_ENABLED(STM32_QSPI_USE_QUAD_IO)) {
-		const enum jesd216_mode_type supported_modes[] = { JESD216_MODE_114,
+		enum jesd216_mode_type supported_modes[] = { JESD216_MODE_114,
 								   JESD216_MODE_144 };
+		int nr_of_modes = ARRAY_SIZE(supported_modes);
+		if (data->desired_mode != STM32_QSPI_UNKNOWN_MODE) {
+			supported_modes[0] = data->desired_mode;
+			nr_of_modes = 1;
+		}
 		struct jesd216_bfp_dw15 dw15;
 		struct jesd216_instr res;
 
 		/* reset active mode */
 		data->mode = STM32_QSPI_UNKNOWN_MODE;
 
-		/* query supported read modes, begin from the slowest */
-		for (size_t i = 0; i < ARRAY_SIZE(supported_modes); ++i) {
+		/* query supported read modes, either from the desired or begin from the slowest */
+		for (size_t i = 0; i < nr_of_modes; ++i) {
 			rc = jesd216_bfp_read_support(php, bfp, supported_modes[i], &res);
 			if (rc >= 0) {
 				LOG_INF("Quad read mode %d instr [0x%x] supported",
@@ -1273,6 +1279,11 @@ static void flash_stm32_qspi_irq_config_func(const struct device *dev);
 		    (_CONCAT(SPI_NOR_CMD_, DT_STRING_TOKEN(DT_DRV_INST(inst), writeoc))),    \
 		    ((default_value)))
 
+#define DT_READOC_PROP_OR(inst, default_value)                                              \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, readoc),                                    \
+		    (_CONCAT(JESD216_, DT_STRING_TOKEN(DT_DRV_INST(inst), readoc))),         \
+		    ((default_value)))
+
 #define DT_QER_PROP_OR(inst, default_value)                                                  \
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, quad_enable_requirements),                   \
 		    (_CONCAT(JESD216_DW15_QER_VAL_,                                          \
@@ -1310,6 +1321,7 @@ static struct flash_stm32_qspi_data flash_stm32_qspi_dev_data = {
 	},
 	.qer_type = DT_QER_PROP_OR(0, JESD216_DW15_QER_VAL_S1B6),
 	.qspi_write_cmd = DT_WRITEOC_PROP_OR(0, SPI_NOR_CMD_PP_1_4_4),
+	.desired_mode = DT_READOC_PROP_OR(0, STM32_QSPI_UNKNOWN_MODE),
 	QSPI_DMA_CHANNEL(STM32_QSPI_NODE, tx_rx)
 };
 

--- a/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
@@ -53,8 +53,9 @@ properties:
       type: string
       required: false
       enum:
-        - "PP_1_1_4"      # Quad data line SPI, PP 1-1-4 (0x32)
-        - "PP_1_4_4"      # Quad data line SPI, PP 1-4-4 (0x38)
+        - "MODE_111"      # Quad data line SPI, PP 1-1-1 (0x02)
+        - "MODE_114"      # Quad data line SPI, PP 1-1-4 (0x32)
+        - "MODE_144"      # Quad data line SPI, PP 1-4-4 (0x38)
       description: |
         The value encodes number of I/O lines used for the opcode,
         address, and data.

--- a/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
@@ -64,3 +64,19 @@ properties:
         supporting 1-4-4 mode also would support fast page programming.
 
         If absent, then 1-4-4 program page is used in quad mode.
+    readoc:
+      type: string
+      required: false
+      enum:
+        - "MODE_114"      # Quad data line SPI, Mode 1-1-4
+        - "MODE_144"      # Quad data line SPI, Mode 1-4-4
+      description: |
+        The value encodes number of I/O lines used for the opcode,
+        address, and data.
+
+        Information about quad page program opcodes is present in the
+        SFDP tables, nevertheless with this option the values can be
+        overwritten if desired.
+
+        If absent, the fastest reading method listed in the SFDP tables
+        will be chosen.

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -65,6 +65,7 @@ struct flash_area {
 	 * device_get_binding().
 	 */
 	const char *fa_dev_name;
+	const char *fa_label;
 };
 
 /**

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -564,23 +564,23 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_fs_mount,
 #endif
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_fs,
-	SHELL_CMD(cd, NULL, "Change working directory", cmd_cd),
-	SHELL_CMD(ls, NULL, "List files in current directory", cmd_ls),
-	SHELL_CMD_ARG(mkdir, NULL, "Create directory", cmd_mkdir, 2, 0),
+	SHELL_CMD_ARG(cd, NULL, "Change working directory\ncd <path>", cmd_cd, 2, 0),
+	SHELL_CMD_ARG(ls, NULL, "List files in current directory\nls [<path>]", cmd_ls, 1, 1),
+	SHELL_CMD_ARG(mkdir, NULL, "Create directory\nmkdir <directory>", cmd_mkdir, 2, 0),
 #if defined(CONFIG_FAT_FILESYSTEM_ELM)		\
 	|| defined(CONFIG_FILE_SYSTEM_LITTLEFS)
 	SHELL_CMD(mount, &sub_fs_mount,
 		  "<Mount fs, syntax:- fs mount <fs type> <mount-point>", NULL),
 #endif
 	SHELL_CMD(pwd, NULL, "Print current working directory", cmd_pwd),
-	SHELL_CMD_ARG(read, NULL, "Read from file", cmd_read, 2, 255),
+	SHELL_CMD_ARG(read, NULL, "Read from file\nread <path> [<length>] [<offset>]", cmd_read, 2, 2),
 	SHELL_CMD_ARG(cat, NULL,
-		"Concatenate files and print on the standard output",
-		cmd_cat, 2, 255),
-	SHELL_CMD_ARG(rm, NULL, "Remove file", cmd_rm, 2, 0),
-	SHELL_CMD_ARG(statvfs, NULL, "Show file system state", cmd_statvfs, 2, 0),
-	SHELL_CMD_ARG(trunc, NULL, "Truncate file", cmd_trunc, 2, 255),
-	SHELL_CMD_ARG(write, NULL, "Write file", cmd_write, 3, 255),
+		"Concatenate files and print on the standard output\ncat <file> [<file>...]",
+		cmd_cat, 2, CONFIG_SHELL_ARGC_MAX - 2),
+	SHELL_CMD_ARG(rm, NULL, "Remove file\nrm <file>", cmd_rm, 2, 0),
+	SHELL_CMD_ARG(statvfs, NULL, "Show file system state\nstatvfs <mount-point>", cmd_statvfs, 2, 0),
+	SHELL_CMD_ARG(trunc, NULL, "Truncate file\ntrunc <file> [<length>]", cmd_trunc, 2, 1),
+	SHELL_CMD_ARG(write, NULL, "Write file with data in hex format\nWith no given offset it is appended to the file\nwrite <file> [-o <offset>] <data> [<data>...]", cmd_write, 3, CONFIG_SHELL_ARGC_MAX - 3),
 	SHELL_SUBCMD_SET_END
 );
 

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -274,7 +274,7 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	if (dirent.type != FS_DIR_ENTRY_FILE) {
-		shell_error(shell, "Note a file %s", path);
+		shell_error(shell, "Not a file %s", path);
 		return -ENOEXEC;
 	}
 
@@ -330,6 +330,31 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	fs_close(&file);
+
+	return 0;
+}
+
+static int cmd_size(const struct shell *shell, size_t argc, char **argv)
+{
+	char path[MAX_PATH_LEN];
+	struct fs_dirent dirent;
+	int err;
+
+	create_abs_path(argv[1], path, sizeof(path));
+
+	err = fs_stat(path, &dirent);
+	if (err) {
+		shell_error(shell, "Failed to obtain file %s (err: %d)",
+			    path, err);
+		return -ENOEXEC;
+	}
+
+	if (dirent.type != FS_DIR_ENTRY_FILE) {
+		shell_error(shell, "Not a file %s", path);
+		return -ENOEXEC;
+	}
+
+	shell_print(shell, "%zd", dirent.size);
 
 	return 0;
 }
@@ -573,7 +598,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_fs,
 		  "<Mount fs, syntax:- fs mount <fs type> <mount-point>", NULL),
 #endif
 	SHELL_CMD(pwd, NULL, "Print current working directory", cmd_pwd),
-	SHELL_CMD_ARG(read, NULL, "Read from file\nread <path> [<length>] [<offset>]", cmd_read, 2, 2),
+	SHELL_CMD_ARG(read, NULL, "Read from file\nread <file> [<length>] [<offset>]", cmd_read, 2, 2),
+	SHELL_CMD_ARG(size, NULL, "Get file size\nsize <file>", cmd_size, 2, 0),
 	SHELL_CMD_ARG(cat, NULL,
 		"Concatenate files and print on the standard output\ncat <file> [<file>...]",
 		cmd_cat, 2, CONFIG_SHELL_ARGC_MAX - 2),

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -135,6 +135,14 @@ config SHELL_PROMPT_RTT
 	help
 	  Displayed prompt name for RTT backend.
 
+config SHELL_RTT_BUFFER
+	int "Buffer number used for shell output."
+	range 0 SEGGER_RTT_MAX_NUM_UP_BUFFERS
+	default 0
+	help
+	  Select index of up-buffer used for shell output, by default it uses
+	  terminal up-buffer and its settings.
+
 config SHELL_RTT_RX_POLL_PERIOD
 	int "RX polling period (in milliseconds)"
 	default 10

--- a/subsys/shell/backends/shell_rtt.c
+++ b/subsys/shell/backends/shell_rtt.c
@@ -9,9 +9,10 @@
 #include <SEGGER_RTT.h>
 #include <zephyr/logging/log.h>
 
-BUILD_ASSERT(!(IS_ENABLED(CONFIG_LOG_BACKEND_RTT) &&
-	       CONFIG_SHELL_RTT_BUFFER == CONFIG_LOG_BACKEND_RTT_BUFFER),
+#if IS_ENABLED(CONFIG_LOG_BACKEND_RTT)
+BUILD_ASSERT(!(CONFIG_SHELL_RTT_BUFFER == CONFIG_LOG_BACKEND_RTT_BUFFER),
 	     "Conflicting log RTT backend enabled on the same channel");
+#endif
 
 static uint8_t shell_rtt_up_buf[CONFIG_SEGGER_RTT_BUFFER_SIZE_UP];
 static uint8_t shell_rtt_down_buf[CONFIG_SEGGER_RTT_BUFFER_SIZE_DOWN];

--- a/subsys/shell/backends/shell_rtt.c
+++ b/subsys/shell/backends/shell_rtt.c
@@ -10,8 +10,11 @@
 #include <zephyr/logging/log.h>
 
 BUILD_ASSERT(!(IS_ENABLED(CONFIG_LOG_BACKEND_RTT) &&
-	       COND_CODE_0(CONFIG_LOG_BACKEND_RTT_BUFFER, (1), (0))),
+	       CONFIG_SHELL_RTT_BUFFER == CONFIG_LOG_BACKEND_RTT_BUFFER),
 	     "Conflicting log RTT backend enabled on the same channel");
+
+static uint8_t shell_rtt_up_buf[CONFIG_SEGGER_RTT_BUFFER_SIZE_UP];
+static uint8_t shell_rtt_down_buf[CONFIG_SEGGER_RTT_BUFFER_SIZE_DOWN];
 
 SHELL_RTT_DEFINE(shell_transport_rtt);
 SHELL_DEFINE(shell_rtt, CONFIG_SHELL_PROMPT_RTT, &shell_transport_rtt,
@@ -27,7 +30,7 @@ static void timer_handler(struct k_timer *timer)
 {
 	const struct shell_rtt *sh_rtt = k_timer_user_data_get(timer);
 
-	if (SEGGER_RTT_HasData(0)) {
+	if (SEGGER_RTT_HasData(CONFIG_SHELL_RTT_BUFFER)) {
 		sh_rtt->handler(SHELL_TRANSPORT_EVT_RX_RDY, sh_rtt->context);
 	}
 }
@@ -46,6 +49,16 @@ static int init(const struct shell_transport *transport,
 	k_timer_user_data_set(&sh_rtt->timer, (void *)sh_rtt);
 	k_timer_start(&sh_rtt->timer, K_MSEC(CONFIG_SHELL_RTT_RX_POLL_PERIOD),
 		      K_MSEC(CONFIG_SHELL_RTT_RX_POLL_PERIOD));
+
+	if (CONFIG_SHELL_RTT_BUFFER > 0) {
+		SEGGER_RTT_ConfigUpBuffer(CONFIG_SHELL_RTT_BUFFER, "Shell",
+					  shell_rtt_up_buf, sizeof(shell_rtt_up_buf),
+					  SEGGER_RTT_MODE_NO_BLOCK_SKIP);
+
+		SEGGER_RTT_ConfigDownBuffer(CONFIG_SHELL_RTT_BUFFER, "Shell",
+					  shell_rtt_down_buf, sizeof(shell_rtt_down_buf),
+					  SEGGER_RTT_MODE_NO_BLOCK_SKIP);
+	}
 
 	return 0;
 }
@@ -78,12 +91,12 @@ static int write(const struct shell_transport *transport,
 	const uint8_t *data8 = (const uint8_t *)data;
 
 	if (rtt_blocking) {
-		*cnt = SEGGER_RTT_WriteNoLock(0, data8, length);
-		while (SEGGER_RTT_HasDataUp(0)) {
+		*cnt = SEGGER_RTT_WriteNoLock(CONFIG_SHELL_RTT_BUFFER, data8, length);
+		while (SEGGER_RTT_HasDataUp(CONFIG_SHELL_RTT_BUFFER)) {
 			/* empty */
 		}
 	} else {
-		*cnt = SEGGER_RTT_Write(0, data8, length);
+		*cnt = SEGGER_RTT_Write(CONFIG_SHELL_RTT_BUFFER, data8, length);
 	}
 
 	sh_rtt->handler(SHELL_TRANSPORT_EVT_TX_RDY, sh_rtt->context);
@@ -94,7 +107,7 @@ static int write(const struct shell_transport *transport,
 static int read(const struct shell_transport *transport,
 		void *data, size_t length, size_t *cnt)
 {
-	*cnt = SEGGER_RTT_Read(0, data, length);
+	*cnt = SEGGER_RTT_Read(CONFIG_SHELL_RTT_BUFFER, data, length);
 
 	return 0;
 }

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -26,6 +26,8 @@
 #define SHELL_HELP_STATISTICS		"Shell statistics."
 #define SHELL_HELP_STATISTICS_SHOW	\
 	"Get shell statistics for the Logger module."
+#define SHELL_HELP_STATISTICS_ARGLEN	\
+	"Return the maximum number of argumunts allowed in a command."
 #define SHELL_HELP_STATISTICS_RESET	\
 	"Reset shell statistics for the Logger module."
 #define SHELL_HELP_RESIZE						\
@@ -315,6 +317,17 @@ static int cmd_shell_stats_show(const struct shell *shell, size_t argc,
 	return 0;
 }
 
+static int cmd_arglen(const struct shell *shell, size_t argc,
+				char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	shell_print(shell, "%d", CONFIG_SHELL_ARGC_MAX);
+
+	return 0;
+}
+
 static int cmd_shell_stats_reset(const struct shell *shell,
 				 size_t argc, char **argv)
 {
@@ -429,6 +442,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_shell,
 	SHELL_CMD_ARG(echo, &m_sub_echo, SHELL_HELP_ECHO, cmd_echo, 1, 1),
 	SHELL_COND_CMD(CONFIG_SHELL_STATS, stats, &m_sub_shell_stats,
 			SHELL_HELP_STATISTICS, NULL),
+	SHELL_CMD(arglen, NULL, SHELL_HELP_STATISTICS_ARGLEN,
+			cmd_arglen),
 	SHELL_SUBCMD_SET_END
 );
 

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -14,6 +14,7 @@
 	{.fa_id = DT_FIXED_PARTITION_ID(part),				\
 	 .fa_off = DT_REG_ADDR(part),					\
 	 .fa_dev_name = DT_LABEL(DT_MTD_FROM_FIXED_PARTITION(part)),	\
+	 .fa_label = DT_LABEL(part),	\
 	 .fa_size = DT_REG_SIZE(part),},
 
 #define FOREACH_PARTITION(n) DT_FOREACH_CHILD(DT_DRV_INST(n), FLASH_AREA_FOO)

--- a/subsys/storage/flash_map/flash_map_shell.c
+++ b/subsys/storage/flash_map/flash_map_shell.c
@@ -23,18 +23,18 @@ static void fa_cb(const struct flash_area *fa, void *user_data)
 {
 	struct shell *shell = user_data;
 
-	shell_print(shell, "%-4d %-8d %-20s  0x%-10x 0x%-12x",
+	shell_print(shell, "%-4d %-8d %-20s %-20s 0x%-10x 0x%-12x",
 		    fa->fa_id, fa->fa_device_id, fa->fa_dev_name,
-		    fa->fa_off, fa->fa_size);
+		    fa->fa_label, fa->fa_off, fa->fa_size);
 }
 
 static int cmd_flash_map_list(const struct shell *shell, size_t argc,
 			      char **argv)
 {
-	shell_print(shell, "ID | Device | Device Name"
-		    "       |   Offset   |   Size");
-	shell_print(shell, "-------------------------"
-		    "------------------------------");
+	shell_print(shell, "ID | Device | Device Name        "
+		    "| Label              | Offset   | Size");
+	shell_print(shell, "---------------------------------"
+		    "---------------------------------------------");
 	flash_area_foreach(fa_cb, (struct shell *)shell);
 	return 0;
 }

--- a/subsys/storage/flash_map/flash_map_shell.c
+++ b/subsys/storage/flash_map/flash_map_shell.c
@@ -23,7 +23,7 @@ static void fa_cb(const struct flash_area *fa, void *user_data)
 {
 	struct shell *shell = user_data;
 
-	shell_print(shell, "%-4d %-8d %-20s %-20s 0x%-10x 0x%-12x",
+	shell_print(shell, "%-4d %-8d %-20s %-20s 0x%-10lx 0x%-12x",
 		    fa->fa_id, fa->fa_device_id, fa->fa_dev_name,
 		    fa->fa_label, fa->fa_off, fa->fa_size);
 }
@@ -32,7 +32,7 @@ static int cmd_flash_map_list(const struct shell *shell, size_t argc,
 			      char **argv)
 {
 	shell_print(shell, "ID | Device | Device Name        "
-		    "| Label              | Offset   | Size");
+		    "| Label              | Offset     | Size");
 	shell_print(shell, "---------------------------------"
 		    "---------------------------------------------");
 	flash_area_foreach(fa_cb, (struct shell *)shell);


### PR DESCRIPTION
This PR has an addition to the STM32 QSPI flash driver. Furthermore, a lot of improvements are made to the Zephyr shell system in order to improve provisioning of the flash through scripting. Below an overview of all the changes:

**Shell in general**

- Made the shell RTT channel configurable in the project config. Now the shell and logging can be used on different RTT channels
- Added a command to get the maximum number of arguments that can be supplied to the shell, for easy shell scripting

**Flash shell**

- Made verification after write optional through parameter input to speedup flash writes
- Added new command to write data to flash trough a separate RTT channel to increase write speed

**Flash map shell**

- Added the labels from the device tree for each partition to the flash map table such that partitions can easily be found based on their label

**File system shell**

- Added new command to just get the file size, for easy shell scripting
- Update of the available commands regarding description and number of arguments

**STM32 flash driver**

- Added option to select write mode 111
- Added option to select the mode for reading from the flash instead of taking the one from the SFDP tables