### PR TITLE
DECO-84 - Transaction log

### DIFF
--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -815,6 +815,19 @@ static int str_encode(const char **str, json_append_bytes_t append_bytes,
 	return ret;
 }
 
+static int null_encode(const char **str, json_append_bytes_t append_bytes,
+		      void *data)
+{
+	int ret;
+
+	ret = append_bytes("null", 4, data);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return ret;
+}
+
 static int num_encode(const int32_t *num, json_append_bytes_t append_bytes,
 		      void *data)
 {
@@ -862,6 +875,8 @@ static int encode(const struct json_obj_descr *descr, const void *val,
 				       ptr, append_bytes, data);
 	case JSON_TOK_NUMBER:
 		return num_encode(ptr, append_bytes, data);
+	case JSON_TOK_NULL:
+		return null_encode(ptr, append_bytes, data);
 	default:
 		return -EINVAL;
 	}


### PR DESCRIPTION
Simple addition to the Zephyr JSON encoder to also be able to encode NULL statements. This is part of the JSON standard and was used in the old DBI project. Therefore, to make the new DBI project backwards compatible, it was added to this encoder as well.