### PR TITLE
DECO-83 - Events log

### DIFF
--- a/include/zephyr/fs/fcb.h
+++ b/include/zephyr/fs/fcb.h
@@ -258,6 +258,18 @@ int fcb_walk(struct fcb *fcb, struct flash_sector *sector, fcb_walk_cb cb,
 int fcb_getnext(struct fcb *fcb, struct fcb_entry *loc);
 
 /**
+ * Get last fcb entry location.
+ *
+ * Function to obtain last fcb entry location
+ *
+ * @param[in] fcb FCB instance structure.
+ * @param[out] loc entry location information
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int fcb_getlast(struct fcb *fcb, struct fcb_entry *loc);
+
+/**
  * Rotate fcb sectors
  *
  * Function erases the data from oldest sector. Upon that the next sector

--- a/include/zephyr/fs/fcb.h
+++ b/include/zephyr/fs/fcb.h
@@ -180,6 +180,31 @@ int fcb_append(struct fcb *fcb, uint16_t len, struct fcb_entry *loc);
 int fcb_append_finish(struct fcb *fcb, struct fcb_entry *append_loc);
 
 /**
+ * Extracts first entry from circular buffer.
+ *
+ * When reading the
+ * contents for the entry, use loc->fe_sector and loc->fe_data_off with
+ * flash_area_read() to fcb flash_area.
+ * When you're finished, call fcb_extract_finish() with loc as argument.
+ *
+ * @param[in] fcb FCB instance structure.
+ * @param[out] loc entry location information
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int fcb_extract(struct fcb *fcb, struct fcb_entry *loc);
+
+/**
+ * Finishes entry extraction operation.
+ *
+ * @param[in] fcb FCB instance structure.
+ * @param[in] extract_loc entry location information
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int fcb_extract_finish(struct fcb *fcb, struct fcb_entry *extract_loc);
+
+/**
  * FCB Walk callback function type.
  *
  * Type of function which is expected to be called while walking over fcb

--- a/subsys/fs/fcb/CMakeLists.txt
+++ b/subsys/fs/fcb/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 zephyr_sources(
   fcb_append.c
+  fcb_extract.c
   fcb.c
   fcb_elem_info.c
   fcb_getnext.c

--- a/subsys/fs/fcb/fcb.c
+++ b/subsys/fs/fcb/fcb.c
@@ -195,8 +195,18 @@ fcb_free_sector_cnt(struct fcb *fcb)
 int
 fcb_is_empty(struct fcb *fcb)
 {
-	return (fcb->f_active.fe_sector == fcb->f_oldest &&
-	  fcb->f_active.fe_elem_off == fcb_len_in_flash(fcb, sizeof(struct fcb_disk_area)));
+	if (fcb->f_active.fe_sector != fcb->f_oldest) {
+		return 0;
+	}
+	if (fcb->f_active.fe_elem_off == fcb_len_in_flash(fcb, sizeof(struct fcb_disk_area))) {
+		return 1;
+	}
+	struct fcb_entry loc;
+	(void)memset(&loc, 0, sizeof(loc));
+	if (fcb_getnext(fcb, &loc) != 0) {
+		return 1;
+	}
+	return 0;
 }
 
 /**

--- a/subsys/fs/fcb/fcb_extract.c
+++ b/subsys/fs/fcb/fcb_extract.c
@@ -46,7 +46,7 @@ fcb_extract_finish_nolock(struct fcb *fcb, struct fcb_entry *loc)
 
 	while (write_len > 0) {
 		rc = fcb_flash_write(fcb, loc->fe_sector, loc->fe_data_off,
-							 buffer, MIN(write_len, max_write_len));
+		                     buffer, MIN(write_len, max_write_len));
 		if (rc) {
 			return -EIO;
 		}
@@ -62,7 +62,7 @@ fcb_extract_finish_nolock(struct fcb *fcb, struct fcb_entry *loc)
 
 	off = loc->fe_data_off + total_data_len;
 	rc = fcb_flash_read(fcb, loc->fe_sector, off,
-						buffer, crc_len);
+	                    buffer, crc_len);
 	if (rc) {
 		return -EIO;
 	}
@@ -72,7 +72,7 @@ fcb_extract_finish_nolock(struct fcb *fcb, struct fcb_entry *loc)
 		// Overwrite the old CRC to really invalidate the element
 		(void)memset(buffer, 0, sizeof(buffer));
 		rc = fcb_flash_write(fcb, loc->fe_sector, off,
-							 buffer, crc_len);
+		                     buffer, crc_len);
 		if (rc) {
 			return -EIO;
 		}

--- a/subsys/fs/fcb/fcb_extract.c
+++ b/subsys/fs/fcb/fcb_extract.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017 Nordic Semiconductor ASA
+ * Copyright (c) 2015 Runtime Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+#include <string.h>
+
+#include <zephyr/fs/fcb.h>
+#include "fcb_priv.h"
+
+int
+fcb_extract(struct fcb *fcb, struct fcb_entry *loc)
+{
+	int rc;
+
+	rc = k_mutex_lock(&fcb->f_mtx, K_FOREVER);
+	if (rc) {
+		return -EINVAL;
+	}
+	memset(loc, 0, sizeof(struct fcb_entry));
+	rc = fcb_getnext_nolock(fcb, loc);
+	k_mutex_unlock(&fcb->f_mtx);
+
+	return rc;
+}
+
+int
+fcb_extract_finish_nolock(struct fcb *fcb, struct fcb_entry *loc)
+{
+	int rc;
+	uint8_t buffer[MAX(fcb->f_align, FCB_TMP_BUF_SZ)];
+	uint8_t crc8[fcb->f_align];
+	off_t off;
+
+	(void)memset(buffer, 0, sizeof(buffer));
+	uint16_t total_len = fcb_len_in_flash(fcb, loc->fe_data_len);
+	uint16_t max_write_len = sizeof(buffer);
+	while (fcb_len_in_flash(fcb, max_write_len) > sizeof(buffer)) {
+		max_write_len /= 2;
+	}
+
+	while (total_len > 0) {
+		rc = fcb_flash_write(fcb, loc->fe_sector, loc->fe_data_off,
+							 buffer, MIN(total_len, max_write_len));
+		if (rc) {
+			return -EIO;
+		}
+		total_len -= MIN(total_len, max_write_len);
+	}
+
+	(void)memset(crc8, 0xFF, sizeof(crc8));
+
+	rc = fcb_elem_crc8(fcb, loc, &crc8[0]);
+	if (rc) {
+		return rc;
+	}
+
+	off = loc->fe_data_off + fcb_len_in_flash(fcb, loc->fe_data_len);
+	rc = fcb_flash_read(fcb, loc->fe_sector, off,
+						buffer, fcb_len_in_flash(fcb, FCB_CRC_SZ));
+	if (rc) {
+		return -EIO;
+	}
+
+	if (crc8[0] == buffer[0]) {
+		(void)memset(buffer, 0, sizeof(buffer));
+		rc = fcb_flash_write(fcb, loc->fe_sector, off,
+							 buffer, fcb_len_in_flash(fcb, FCB_CRC_SZ));
+		if (rc) {
+			return -EIO;
+		}
+	}
+
+	return rc;
+}
+
+int
+fcb_extract_finish(struct fcb *fcb, struct fcb_entry *extract_loc)
+{
+	int rc;
+
+	rc = k_mutex_lock(&fcb->f_mtx, K_FOREVER);
+	if (rc) {
+		return -EINVAL;
+	}
+	rc = fcb_extract_finish_nolock(fcb, extract_loc);
+	k_mutex_unlock(&fcb->f_mtx);
+
+	return rc;
+}

--- a/subsys/fs/fcb/fcb_priv.h
+++ b/subsys/fs/fcb/fcb_priv.h
@@ -68,6 +68,9 @@ int fcb_getnext_in_sector(struct fcb *fcb, struct fcb_entry *loc);
 struct flash_sector *fcb_getnext_sector(struct fcb *fcb,
 					struct flash_sector *sector);
 int fcb_getnext_nolock(struct fcb *fcb, struct fcb_entry *loc);
+int fcb_getlast_nolock(struct fcb *fcb, struct fcb_entry *loc);
+
+int fcb_extract_finish_nolock(struct fcb *fcb, struct fcb_entry *loc);
 
 int fcb_elem_info(struct fcb *fcb, struct fcb_entry *loc);
 int fcb_elem_crc8(struct fcb *fcb, struct fcb_entry *loc, uint8_t *crc8p);


### PR DESCRIPTION
For the implementation the DECO events log the underlying storage system chosen was the Zephyr FCB. This PR adds some improvements to the Zephyr FCB in order to facilitate the DECO development.

Extended testing was done into the potential problem identified by @n-nievergeld and @DennisOfTheBurn regarding interger overflow in the FCB sector numbering. Nevertheless, after the testing, the system works perfectly out of the box and no changes was made to fix any issues found.