### PR TITLE
DECO-118 Add cmux recovery to the GSM PPP driver

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1133,13 +1133,13 @@ void gsm_ppp_recover_cmux(const struct device *dev)
 	modem_cmd_handler_disable_eol(&gsm->context.cmd_handler);
 
 	/*
-     * See https://www.quectel.com/wp-content/uploads/2021/03/Quectel_BG96_MUX_Application_Note_V1.0.pdf
-     * chapter 5.7. Close-down of Multiplexer
-     * for the specification of the commands.
-     */
+	 * See https://www.quectel.com/wp-content/uploads/2021/03/Quectel_BG96_MUX_Application_Note_V1.0.pdf
+	 * chapter 5.7. Close-down of Multiplexer
+	 * for the specification of the commands.
+	 */
 	int i;
 	for (i = 0; i < ARRAY_SIZE(disconnect_cmux); i++)
-    {
+	{
 		(void)modem_cmd_send_nolock(&gsm->context.iface,
 				    &gsm->context.cmd_handler,
 				    NULL, 0,

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1107,6 +1107,17 @@ void gsm_ppp_start(const struct device *dev)
 	(void)gsm_work_reschedule(&gsm->gsm_configure_work, K_NO_WAIT);
 }
 
+void gsm_ppp_cancel(const struct device *dev)
+{
+	struct gsm_modem *gsm = dev->data;
+	struct k_work_sync work_sync;
+
+	(void)k_work_cancel_delayable_sync(&gsm->gsm_configure_work, &work_sync);
+	if (IS_ENABLED(CONFIG_GSM_MUX)) {
+		(void)k_work_cancel_delayable_sync(&gsm->rssi_work_handle, &work_sync);
+	}
+}
+
 void gsm_ppp_stop(const struct device *dev)
 {
 	struct gsm_modem *gsm = dev->data;

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1132,11 +1132,6 @@ void gsm_ppp_recover_cmux(const struct device *dev)
 
 	modem_cmd_handler_disable_eol(&gsm->context.cmd_handler);
 
-	/*
-	 * See https://www.quectel.com/wp-content/uploads/2021/03/Quectel_BG96_MUX_Application_Note_V1.0.pdf
-	 * chapter 5.7. Close-down of Multiplexer
-	 * for the specification of the commands.
-	 */
 	int i;
 	for (i = 0; i < ARRAY_SIZE(disconnect_cmux); i++)
 	{

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -50,6 +50,13 @@ LOG_MODULE_REGISTER(modem_gsm, CONFIG_MODEM_LOG_LEVEL);
 	#define GSM_RSSI_MAXVAL         -51
 #endif
 
+const uint8_t disconnect_cmux[4][9] = {
+	{ 0xF9, 0x07, 0x53, 0x01, 0x3F, 0xF9, 0x00, 0x00, 0x00 },
+	{ 0xF9, 0x0B, 0x53, 0x01, 0xB8, 0xF9, 0x00, 0x00, 0x00 },
+	{ 0xF9, 0x0F, 0x53, 0x01, 0x7A, 0xF9, 0x00, 0x00, 0x00 },
+	{ 0xF9, 0x03, 0xEF, 0x05, 0xC3, 0x01, 0xF2, 0xF9, 0x00 },
+};
+
 /* Modem network registration state */
 enum network_state {
 	GSM_NET_INIT = -1,
@@ -1107,9 +1114,8 @@ void gsm_ppp_start(const struct device *dev)
 	(void)gsm_work_reschedule(&gsm->gsm_configure_work, K_NO_WAIT);
 }
 
-void gsm_ppp_cancel(const struct device *dev)
+void gsm_ppp_cancel(struct gsm_modem *gsm)
 {
-	struct gsm_modem *gsm = dev->data;
 	struct k_work_sync work_sync;
 
 	(void)k_work_cancel_delayable_sync(&gsm->gsm_configure_work, &work_sync);
@@ -1118,16 +1124,38 @@ void gsm_ppp_cancel(const struct device *dev)
 	}
 }
 
+void gsm_ppp_recover_cmux(const struct device *dev)
+{
+	struct gsm_modem *gsm = dev->data;
+
+	gsm_ppp_cancel(gsm);
+
+	modem_cmd_handler_disable_eol(&gsm->context.cmd_handler);
+
+	/*
+     * See https://www.quectel.com/wp-content/uploads/2021/03/Quectel_BG96_MUX_Application_Note_V1.0.pdf
+     * chapter 5.7. Close-down of Multiplexer
+     * for the specification of the commands.
+     */
+	int i;
+	for (i = 0; i < ARRAY_SIZE(disconnect_cmux); i++)
+    {
+		(void)modem_cmd_send_nolock(&gsm->context.iface,
+				    &gsm->context.cmd_handler,
+				    NULL, 0,
+				    disconnect_cmux[i], &gsm->sem_response,
+				    GSM_CMD_AT_TIMEOUT);
+	}
+
+	modem_cmd_handler_restore_eol(&gsm->context.cmd_handler);
+}
+
 void gsm_ppp_stop(const struct device *dev)
 {
 	struct gsm_modem *gsm = dev->data;
 	struct net_if *iface = gsm->iface;
-	struct k_work_sync work_sync;
 
-	(void)k_work_cancel_delayable_sync(&gsm->gsm_configure_work, &work_sync);
-	if (IS_ENABLED(CONFIG_GSM_MUX)) {
-		(void)k_work_cancel_delayable_sync(&gsm->rssi_work_handle, &work_sync);
-	}
+	gsm_ppp_cancel(gsm);
 
 	net_if_l2(iface)->enable(iface, false);
 

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1145,6 +1145,7 @@ void gsm_ppp_recover_cmux(const struct device *dev)
 				    NULL, 0,
 				    disconnect_cmux[i], &gsm->sem_response,
 				    GSM_CMD_AT_TIMEOUT);
+		k_msleep(1);
 	}
 
 	modem_cmd_handler_restore_eol(&gsm->context.cmd_handler);

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -672,3 +672,21 @@ int modem_cmd_handler_init(struct modem_cmd_handler *handler,
 
 	return 0;
 }
+
+void modem_cmd_handler_disable_eol(struct modem_cmd_handler *handler)
+{
+	struct modem_cmd_handler_data *data;
+	data = (struct modem_cmd_handler_data *)(handler->cmd_handler_data);
+	data->eol_len = 0;
+}
+
+void modem_cmd_handler_restore_eol(struct modem_cmd_handler *handler)
+{
+	struct modem_cmd_handler_data *data;
+	data = (struct modem_cmd_handler_data *)(handler->cmd_handler_data);
+	if (data->eol == NULL) {
+		data->eol_len = 0;
+	} else {
+		data->eol_len = strlen(data->eol);
+	}
+}

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -296,6 +296,16 @@ int modem_cmd_handler_tx_lock(struct modem_cmd_handler *handler,
  */
 void modem_cmd_handler_tx_unlock(struct modem_cmd_handler *handler);
 
+/**
+ * @brief  Disable the end of line character(s) after sending a command
+ */
+void modem_cmd_handler_disable_eol(struct modem_cmd_handler *handler);
+
+/**
+ * @brief  Restore the end of line character(s) after sending a command
+ */
+void modem_cmd_handler_restore_eol(struct modem_cmd_handler *handler);
+
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/modem/gsm_ppp.h
+++ b/include/zephyr/drivers/modem/gsm_ppp.h
@@ -31,6 +31,7 @@ struct device;
 typedef void (*gsm_modem_power_cb)(const struct device *, void *);
 
 void gsm_ppp_start(const struct device *dev);
+void gsm_ppp_cancel(const struct device *dev);
 void gsm_ppp_stop(const struct device *dev);
 /** @endcond */
 

--- a/include/zephyr/drivers/modem/gsm_ppp.h
+++ b/include/zephyr/drivers/modem/gsm_ppp.h
@@ -31,7 +31,7 @@ struct device;
 typedef void (*gsm_modem_power_cb)(const struct device *, void *);
 
 void gsm_ppp_start(const struct device *dev);
-void gsm_ppp_cancel(const struct device *dev);
+void gsm_ppp_recover_cmux(const struct device *dev);
 void gsm_ppp_stop(const struct device *dev);
 /** @endcond */
 


### PR DESCRIPTION
From the DECO project it turned out that the Quectel modem CMUX needs to be recovered when the connection fails. This was implemented in the DECO project itself. This PR moves the recover code to this driver.