### PR TITLE
DECO-88 - Implement remote wakeup

### DIFF
--- a/drivers/console/gsm_mux.c
+++ b/drivers/console/gsm_mux.c
@@ -723,11 +723,11 @@ static int gsm_dlci_opening(struct gsm_dlci *dlci, dlci_command_cb_t cb)
 					   cb);
 }
 
-int gsm_mux_disconnect(struct gsm_mux *mux, k_timeout_t timeout)
+int gsm_mux_disconnect(struct gsm_mux *mux, uint8_t dlci_address, k_timeout_t timeout)
 {
 	struct gsm_dlci *dlci;
 
-	dlci = gsm_dlci_get(mux, 0);
+	dlci = gsm_dlci_get(mux, dlci_address);
 	if (dlci == NULL) {
 		return -ENOENT;
 	}

--- a/drivers/console/gsm_mux.h
+++ b/drivers/console/gsm_mux.h
@@ -21,7 +21,7 @@ void gsm_mux_recv_buf(struct gsm_mux *mux, uint8_t *buf, int len);
 int gsm_mux_send(struct gsm_mux *mux, uint8_t dlci_address,
 		 const uint8_t *buf, size_t size);
 struct gsm_mux *gsm_mux_create(const struct device *uart);
-int gsm_mux_disconnect(struct gsm_mux *mux, k_timeout_t timeout);
+int gsm_mux_disconnect(struct gsm_mux *mux, uint8_t dlci_address, k_timeout_t timeout);
 void gsm_mux_init(void);
 
 typedef void (*gsm_mux_dlci_created_cb_t)(struct gsm_dlci *dlci,

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -452,6 +452,13 @@ static int attach(const struct device *mux_uart, const struct device *uart,
 	return -ENOENT;
 }
 
+void uart_mux_disconnect(const struct device *dev, uint8_t dlci_address)
+{
+	struct uart_mux_dev_data *dev_data = dev->data;
+
+	gsm_mux_disconnect(dev_data->real_uart->mux, dlci_address, K_SECONDS(1));
+}
+
 static int uart_mux_poll_in(const struct device *dev, unsigned char *p_char)
 {
 	ARG_UNUSED(dev);

--- a/drivers/modem/Kconfig.gsm
+++ b/drivers/modem/Kconfig.gsm
@@ -142,4 +142,12 @@ config GSM_PPP_WORKQ_PRIORITY
 	help
 	  Workqueue scheduling commands configuring the modem.
 
+config MODEM_GMS_ENABLE_SMS
+	bool "SMS support for GSM PPP driver"
+	depends on MODEM_GSM_QUECTEL
+	default n
+	help
+	  Enable SMS messages support such that they can be received.
+	  Currently only BG9X is supported.
+
 endif

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -41,7 +41,7 @@ LOG_MODULE_REGISTER(modem_gsm, CONFIG_MODEM_LOG_LEVEL);
 #define GSM_RETRY_DELAY                 K_MSEC(CONFIG_MODEM_GSM_RETRY_DELAY)
 
 #define GSM_RSSI_RETRY_DELAY_MSEC       2000
-#define GSM_RSSI_RETRIES                10
+#define GSM_RSSI_RETRIES                3
 #define GSM_RSSI_INVALID                -1000
 
 #if defined(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -219,6 +219,21 @@ static int unquoted_atoi(const char *s, int base)
 	return strtol(s, NULL, base);
 }
 
+static char * unquoted_strncpy(char *dest, const char * src, size_t num)
+{
+	if (*src == '"') {
+		src++;
+	}
+
+	strncpy(dest, src, num);
+	dest[num - 1] = '\0';
+	if (dest[strlen(dest) - 1] == '\"') {
+		dest[strlen(dest) - 1] = '\0';
+	}
+
+	return dest;
+}
+
 /*
  * Handler: +COPS: <mode>[0],<format>[1],<oper>[2]
  */
@@ -1297,18 +1312,62 @@ void gsm_ppp_configure_sms_reception(const struct device *dev)
 	}
 }
 
-void gsm_ppp_read_sms(const struct device *dev)
+static struct gsm_ppp_sms_message sms_message;
+
+/* Handler: <SMS message> */
+MODEM_CMD_DEFINE(on_cmd_atcmd_read_sms)
+{
+	if (argc >= 1 && strncmp(argv[0], "+CMGL: ", strlen("+CMGL: ")) == 0) {
+		sms_message.index = atoi(strchr(argv[0], ' '));
+
+		unquoted_strncpy(sms_message.status, argv[1], GSM_PPP_SMS_STATUS_LENGTH);
+
+		unquoted_strncpy(sms_message.origin_address, argv[2], GSM_PPP_SMS_OA_LENGTH);
+
+		unquoted_strncpy(sms_message.origin_name, argv[3], GSM_PPP_SMS_OA_NAME_LENGTH);
+
+		unquoted_strncpy(sms_message.date, argv[4], GSM_PPP_SMS_DATE_LENGTH);
+
+		unquoted_strncpy(sms_message.time, argv[5], GSM_PPP_SMS_TIME_LENGTH);
+	} else if(argc == 1) {
+		size_t out_len;
+
+		sms_message.has_data = true;
+		out_len = net_buf_linearize(sms_message.data,
+						sizeof(sms_message.data) - 1,
+						data->rx_buf, 0, len);
+		sms_message.data[out_len] = '\0';
+	} else {
+		LOG_DBG("Invalid SMS received");
+		sms_message.valid = false;
+	}
+	return 0;
+}
+
+static const struct setup_cmd read_sms_cmds[] = {
+	SETUP_CMD_ARGS_MAX("AT+CMGL=\"REC UNREAD\"", "", on_cmd_atcmd_read_sms, 0U, 8U, ","),
+};
+
+struct gsm_ppp_sms_message * gsm_ppp_read_sms(const struct device *dev)
 {
 	struct gsm_modem *gsm = dev->data;
 	int ret;
 
-	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
-		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+CMGL=\"REC UNREAD\"",
-		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+	memset(&sms_message, 0, sizeof(sms_message));
+	sms_message.valid = true;
+
+	ret = modem_cmd_handler_setup_cmds_nolock(&gsm->context.iface,
+						  &gsm->context.cmd_handler,
+						  read_sms_cmds,
+						  ARRAY_SIZE(read_sms_cmds),
+						  &gsm->sem_response,
+						  GSM_CMD_SETUP_TIMEOUT);
 
 	if (ret < 0) {
 		LOG_DBG("No answer from reading sms messages");
 	}
+
+	return &sms_message;
 }
 
 static void gsm_mgmt_event_handler(struct net_mgmt_event_callback *cb,

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1296,10 +1296,12 @@ void gsm_ppp_set_ring_indicator(const struct device *dev,
 }
 
 static const struct setup_cmd sms_configure_cmds[] = {
+	/* Set SMS message format to text */
 	SETUP_CMD_NOHANDLE("AT+CMGF=1"),
+	/* Set SMS message reporting to message the receiver*/
 	SETUP_CMD_NOHANDLE("AT+CNMI=2,1"),
+	/* Set SMS message character set */
 	SETUP_CMD_NOHANDLE("AT+CSCS=\"IRA\""),
-	SETUP_CMD_NOHANDLE("AT+CREG=2"),
 };
 
 void gsm_ppp_configure_sms_reception(const struct device *dev)

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -784,6 +784,7 @@ attaching:
 
 	LOG_DBG("modem attach returned %d, %s", ret, "read RSSI");
 	gsm->rssi_retries = GSM_RSSI_RETRIES;
+	gsm->minfo.mdm_rssi = GSM_RSSI_INVALID;
 
  attached:
 
@@ -806,7 +807,7 @@ attaching:
 #endif
 	}
 
-	LOG_DBG("modem RSSI: %d, %s", *gsm->context.data_rssi, "enable PPP");
+	LOG_DBG("modem RSSI: %d, %s", gsm->minfo.mdm_rssi, "enable PPP");
 
 	ret = modem_cmd_handler_setup_cmds_nolock(&gsm->context.iface,
 						  &gsm->context.cmd_handler,
@@ -845,8 +846,6 @@ attaching:
 			}
 		}
 		modem_cmd_handler_tx_unlock(&gsm->context.cmd_handler);
-		(void)gsm_work_reschedule(&gsm->rssi_work_handle,
-					  K_SECONDS(CONFIG_MODEM_GSM_RSSI_POLLING_PERIOD));
 	}
 }
 

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1272,49 +1272,28 @@ void gsm_ppp_set_ring_indicator(const struct device *dev,
 	}
 }
 
+static const struct setup_cmd sms_configure_cmds[] = {
+	SETUP_CMD_NOHANDLE("AT+CMGF=1"),
+	SETUP_CMD_NOHANDLE("AT+CNMI=2,1"),
+	SETUP_CMD_NOHANDLE("AT+CSCS=\"IRA\""),
+	SETUP_CMD_NOHANDLE("AT+CREG=2"),
+	SETUP_CMD_NOHANDLE("AT+QRIR"),
+};
+
 void gsm_ppp_configure_sms_reception(const struct device *dev)
 {
 	struct gsm_modem *gsm = dev->data;
 	int ret;
 
-	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
-		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+CMGF=1",
-		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+	ret = modem_cmd_handler_setup_cmds_nolock(&gsm->context.iface,
+						  &gsm->context.cmd_handler,
+						  sms_configure_cmds,
+						  ARRAY_SIZE(sms_configure_cmds),
+						  &gsm->sem_response,
+						  GSM_CMD_SETUP_TIMEOUT);
 
 	if (ret < 0) {
-		LOG_DBG("Could not set SMS message format");
-	}
-
-	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
-		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+CNMI=2,1",
-		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
-
-	if (ret < 0) {
-		LOG_DBG("Could not set SMS event reporting configuration");
-	}
-
-	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
-		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+CSCS=\"IRA\"",
-		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
-
-	if (ret < 0) {
-		LOG_DBG("Could not set SMS character set");
-	}
-
-	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
-		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+CREG=2",
-		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
-
-	if (ret < 0) {
-		LOG_DBG("Could not set network registration setting");
-	}
-
-	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
-		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+QRIR",
-		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
-
-	if (ret < 0) {
-		LOG_DBG("Could not clear any pending ring indicators");
+		LOG_DBG("Could not set SMS configuration");
 	}
 }
 

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1213,6 +1213,67 @@ const struct gsm_ppp_modem_info *gsm_ppp_modem_info(const struct device *dev)
 	return &gsm->minfo;
 }
 
+char * gsm_ppp_get_ring_indicator_behaviour_text(enum ring_indicator_behaviour ring)
+{
+	switch (ring) {
+		case OFF:
+			return "off";
+		case PULSE:
+			return "pulse";
+		case ALWAYS:
+			return "always";
+		case AUTO:
+			return "auto";
+		case WAVE:
+			return "wave";
+		default:
+			LOG_WRN("Unknown ring indicator type");
+			return "";
+	}
+}
+
+int gsm_ppp_set_ring_indicator(const struct device *dev,
+					   enum ring_indicator_behaviour ring,
+					   enum ring_indicator_behaviour other,
+					   enum ring_indicator_behaviour sms)
+{
+	struct gsm_modem *gsm = dev->data;
+	int ret;
+	char cmd_buffer[64];
+
+	snprintf(cmd_buffer, sizeof(cmd_buffer), "AT+QCFG=\"urc/ri/ring\",\"%s\"",
+		gsm_ppp_get_ring_indicator_behaviour_text(ring));
+	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
+		&response_cmds[0], ARRAY_SIZE(response_cmds), cmd_buffer,
+		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+
+	if (ret < 0) {
+		LOG_DBG("No answer to extended ring configuration setting");
+	}
+
+	snprintf(cmd_buffer, sizeof(cmd_buffer), "AT+QCFG=\"urc/ri/other\",\"%s\"",
+		gsm_ppp_get_ring_indicator_behaviour_text(other));
+	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
+		&response_cmds[0], ARRAY_SIZE(response_cmds), cmd_buffer,
+		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+
+	if (ret < 0) {
+		LOG_DBG("No answer to extended other ring configuration setting");
+	}
+
+	snprintf(cmd_buffer, sizeof(cmd_buffer), "AT+QCFG=\"urc/ri/smsincoming\",\"%s\"",
+		gsm_ppp_get_ring_indicator_behaviour_text(sms));
+	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
+		&response_cmds[0], ARRAY_SIZE(response_cmds), cmd_buffer,
+		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+
+	if (ret < 0) {
+		LOG_DBG("No answer to extended sms ring configuration setting");
+	}
+
+	return 1;
+}
+
 static void gsm_mgmt_event_handler(struct net_mgmt_event_callback *cb,
 			  uint32_t mgmt_event, struct net_if *iface)
 {

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1292,7 +1292,6 @@ static const struct setup_cmd sms_configure_cmds[] = {
 	SETUP_CMD_NOHANDLE("AT+CNMI=2,1"),
 	SETUP_CMD_NOHANDLE("AT+CSCS=\"IRA\""),
 	SETUP_CMD_NOHANDLE("AT+CREG=2"),
-	SETUP_CMD_NOHANDLE("AT+QRIR"),
 };
 
 void gsm_ppp_configure_sms_reception(const struct device *dev)
@@ -1310,6 +1309,8 @@ void gsm_ppp_configure_sms_reception(const struct device *dev)
 	if (ret < 0) {
 		LOG_DBG("Could not set SMS configuration");
 	}
+
+	gsm_ppp_clear_ring_indicator(dev);
 }
 
 static struct gsm_ppp_sms_message sms_message;
@@ -1368,6 +1369,34 @@ struct gsm_ppp_sms_message * gsm_ppp_read_sms(const struct device *dev)
 	}
 
 	return &sms_message;
+}
+
+void gsm_ppp_delete_all_sms(const struct device *dev)
+{
+	struct gsm_modem *gsm = dev->data;
+	int ret;
+
+	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
+		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+CMGD=0,4",
+		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+
+	if (ret < 0) {
+		LOG_DBG("Could not delete all SMS messages");
+	}
+}
+
+void gsm_ppp_clear_ring_indicator(const struct device *dev)
+{
+	struct gsm_modem *gsm = dev->data;
+	int ret;
+
+	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
+		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+QRIR",
+		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+
+	if (ret < 0) {
+		LOG_DBG("Could not clear ring indicator");
+	}
 }
 
 static void gsm_mgmt_event_handler(struct net_mgmt_event_callback *cb,

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1352,7 +1352,9 @@ static struct gsm_ppp_sms_message sms_message;
 /* Handler: <SMS message> */
 MODEM_CMD_DEFINE(on_cmd_atcmd_read_sms)
 {
-	if (argc >= 1 && strncmp(argv[0], "+CMGL: ", strlen("+CMGL: ")) == 0) {
+	if (strncmp(argv[0], "+CMTI: ", strlen("+CMTI: ")) == 0) {
+		LOG_DBG("SMS message received by modem");
+	} else if (argc >= 1 && strncmp(argv[0], "+CMGL: ", strlen("+CMGL: ")) == 0) {
 		sms_message.index = atoi(strchr(argv[0], ' '));
 
 		unquoted_strncpy(sms_message.status, argv[1], GSM_PPP_SMS_STATUS_LENGTH);

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -113,6 +113,7 @@ static struct gsm_modem {
 	void *user_data;
 
 	gsm_modem_power_cb modem_on_cb;
+	gsm_modem_power_cb modem_configured_cb;
 	gsm_modem_power_cb modem_off_cb;
 	struct net_mgmt_event_callback gsm_mgmt_cb;
 } gsm;
@@ -861,6 +862,10 @@ attached:
 		}
 		modem_cmd_handler_tx_unlock(&gsm->context.cmd_handler);
 	}
+
+	if (gsm->modem_configured_cb) {
+		gsm->modem_configured_cb(gsm->dev, gsm->user_data);
+	}
 }
 
 static int mux_enable(struct gsm_modem *gsm)
@@ -1215,12 +1220,14 @@ void gsm_ppp_stop(const struct device *dev, bool keep_AT_channel)
 
 void gsm_ppp_register_modem_power_callback(const struct device *dev,
 					   gsm_modem_power_cb modem_on,
+					   gsm_modem_power_cb modem_configured,
 					   gsm_modem_power_cb modem_off,
 					   void *user_data)
 {
 	struct gsm_modem *gsm = dev->data;
 
 	gsm->modem_on_cb = modem_on;
+	gsm->modem_configured_cb = modem_configured;
 	gsm->modem_off_cb = modem_off;
 
 	gsm->user_data = user_data;

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -219,6 +219,7 @@ static int unquoted_atoi(const char *s, int base)
 	return strtol(s, NULL, base);
 }
 
+#if defined(CONFIG_MODEM_GMS_ENABLE_SMS)
 static char * unquoted_strncpy(char *dest, const char * src, size_t num)
 {
 	if (*src == '"') {
@@ -233,6 +234,7 @@ static char * unquoted_strncpy(char *dest, const char * src, size_t num)
 
 	return dest;
 }
+#endif
 
 /*
  * Handler: +COPS: <mode>[0],<format>[1],<oper>[2]
@@ -1236,6 +1238,7 @@ const struct gsm_ppp_modem_info *gsm_ppp_modem_info(const struct device *dev, bo
 	return &gsm->minfo;
 }
 
+#if defined(CONFIG_MODEM_GMS_ENABLE_SMS)
 char * gsm_ppp_get_ring_indicator_behaviour_text(enum ring_indicator_behaviour ring)
 {
 	switch (ring) {
@@ -1409,8 +1412,8 @@ void gsm_ppp_delete_all_sms(const struct device *dev)
 	int ret;
 
 	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
-		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+CMGD=0,4",
-		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+				    &response_cmds[0], ARRAY_SIZE(response_cmds), "AT+CMGD=0,4",
+				    &gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
 
 	if (ret < 0) {
 		LOG_DBG("Could not delete all SMS messages");
@@ -1423,16 +1426,17 @@ void gsm_ppp_clear_ring_indicator(const struct device *dev)
 	int ret;
 
 	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
-		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+QRIR",
-		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+				    &response_cmds[0], ARRAY_SIZE(response_cmds), "AT+QRIR",
+				    &gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
 
 	if (ret < 0) {
 		LOG_DBG("Could not clear ring indicator");
 	}
 }
+#endif /* defined(CONFIG_MODEM_GMS_ENABLE_SMS) */
 
 static void gsm_mgmt_event_handler(struct net_mgmt_event_callback *cb,
-			  uint32_t mgmt_event, struct net_if *iface)
+				   uint32_t mgmt_event, struct net_if *iface)
 {
 	if ((mgmt_event & NET_EVENT_IF_DOWN) != mgmt_event) {
 		return;

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1232,10 +1232,10 @@ char * gsm_ppp_get_ring_indicator_behaviour_text(enum ring_indicator_behaviour r
 	}
 }
 
-int gsm_ppp_set_ring_indicator(const struct device *dev,
+void gsm_ppp_set_ring_indicator(const struct device *dev,
 					   enum ring_indicator_behaviour ring,
-					   enum ring_indicator_behaviour other,
-					   enum ring_indicator_behaviour sms)
+					   enum ring_indicator_behaviour sms,
+					   enum ring_indicator_behaviour other)
 {
 	struct gsm_modem *gsm = dev->data;
 	int ret;
@@ -1248,17 +1248,7 @@ int gsm_ppp_set_ring_indicator(const struct device *dev,
 		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
 
 	if (ret < 0) {
-		LOG_DBG("No answer to extended ring configuration setting");
-	}
-
-	snprintf(cmd_buffer, sizeof(cmd_buffer), "AT+QCFG=\"urc/ri/other\",\"%s\"",
-		gsm_ppp_get_ring_indicator_behaviour_text(other));
-	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
-		&response_cmds[0], ARRAY_SIZE(response_cmds), cmd_buffer,
-		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
-
-	if (ret < 0) {
-		LOG_DBG("No answer to extended other ring configuration setting");
+		LOG_DBG("Could not set ring indicator setting");
 	}
 
 	snprintf(cmd_buffer, sizeof(cmd_buffer), "AT+QCFG=\"urc/ri/smsincoming\",\"%s\"",
@@ -1268,10 +1258,78 @@ int gsm_ppp_set_ring_indicator(const struct device *dev,
 		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
 
 	if (ret < 0) {
-		LOG_DBG("No answer to extended sms ring configuration setting");
+		LOG_DBG("Could not set ring indicator setting for sms");
 	}
 
-	return 1;
+	snprintf(cmd_buffer, sizeof(cmd_buffer), "AT+QCFG=\"urc/ri/other\",\"%s\"",
+		gsm_ppp_get_ring_indicator_behaviour_text(other));
+	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
+		&response_cmds[0], ARRAY_SIZE(response_cmds), cmd_buffer,
+		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+
+	if (ret < 0) {
+		LOG_DBG("Could not set ring indicator setting");
+	}
+}
+
+void gsm_ppp_configure_sms_reception(const struct device *dev)
+{
+	struct gsm_modem *gsm = dev->data;
+	int ret;
+
+	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
+		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+CMGF=1",
+		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+
+	if (ret < 0) {
+		LOG_DBG("Could not set SMS message format");
+	}
+
+	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
+		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+CNMI=2,1",
+		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+
+	if (ret < 0) {
+		LOG_DBG("Could not set SMS event reporting configuration");
+	}
+
+	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
+		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+CSCS=\"IRA\"",
+		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+
+	if (ret < 0) {
+		LOG_DBG("Could not set SMS character set");
+	}
+
+	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
+		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+CREG=2",
+		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+
+	if (ret < 0) {
+		LOG_DBG("Could not set network registration setting");
+	}
+
+	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
+		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+QRIR",
+		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+
+	if (ret < 0) {
+		LOG_DBG("Could not clear any pending ring indicators");
+	}
+}
+
+void gsm_ppp_read_sms(const struct device *dev)
+{
+	struct gsm_modem *gsm = dev->data;
+	int ret;
+
+	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
+		&response_cmds[0], ARRAY_SIZE(response_cmds), "AT+CMGL=\"REC UNREAD\"",
+		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+
+	if (ret < 0) {
+		LOG_DBG("No answer from reading sms messages");
+	}
 }
 
 static void gsm_mgmt_event_handler(struct net_mgmt_event_callback *cb,

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1245,50 +1245,72 @@ char * gsm_ppp_get_ring_indicator_behaviour_text(enum ring_indicator_behaviour r
 			return "pulse";
 		case ALWAYS:
 			return "always";
-		case AUTO:
-			return "auto";
-		case WAVE:
-			return "wave";
 		default:
 			LOG_WRN("Unknown ring indicator type");
 			return "";
 	}
 }
 
+void gsm_ppp_generate_ring_indicator_at_cmd(char * cmd_buffer,
+					    size_t max_len,
+					    char * ring_type,
+					    enum ring_indicator_behaviour setting,
+					    uint16_t pule_duration)
+{
+	if (setting == PULSE) {
+		snprintf(cmd_buffer, max_len, "AT+QCFG=\"%s\",\"%s\",%d",
+			 ring_type,
+			 gsm_ppp_get_ring_indicator_behaviour_text(setting),
+			 pule_duration);
+	} else {
+		snprintf(cmd_buffer, max_len, "AT+QCFG=\"%s\",\"%s\"",
+			 ring_type,
+			 gsm_ppp_get_ring_indicator_behaviour_text(setting));
+	}
+}
+
 void gsm_ppp_set_ring_indicator(const struct device *dev,
-					   enum ring_indicator_behaviour ring,
-					   enum ring_indicator_behaviour sms,
-					   enum ring_indicator_behaviour other)
+				enum ring_indicator_behaviour ring,
+				uint16_t ring_pulse_duration,
+				enum ring_indicator_behaviour sms,
+				uint16_t sms_pulse_duration,
+				enum ring_indicator_behaviour other,
+				uint16_t other_pulse_duration)
 {
 	struct gsm_modem *gsm = dev->data;
 	int ret;
 	char cmd_buffer[64];
 
-	snprintf(cmd_buffer, sizeof(cmd_buffer), "AT+QCFG=\"urc/ri/ring\",\"%s\"",
-		gsm_ppp_get_ring_indicator_behaviour_text(ring));
+	gsm_ppp_generate_ring_indicator_at_cmd(cmd_buffer, sizeof(cmd_buffer),
+					       "urc/ri/ring", ring, ring_pulse_duration);
 	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
-		&response_cmds[0], ARRAY_SIZE(response_cmds), cmd_buffer,
-		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+				    &response_cmds[0], ARRAY_SIZE(response_cmds), cmd_buffer,
+				    &gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
 
 	if (ret < 0) {
 		LOG_DBG("Could not set ring indicator setting");
 	}
 
-	snprintf(cmd_buffer, sizeof(cmd_buffer), "AT+QCFG=\"urc/ri/smsincoming\",\"%s\"",
-		gsm_ppp_get_ring_indicator_behaviour_text(sms));
+	gsm_ppp_generate_ring_indicator_at_cmd(cmd_buffer, sizeof(cmd_buffer),
+					       "urc/ri/smsincoming", sms, sms_pulse_duration);
 	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
-		&response_cmds[0], ARRAY_SIZE(response_cmds), cmd_buffer,
-		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+				    &response_cmds[0], ARRAY_SIZE(response_cmds), cmd_buffer,
+				    &gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
 
 	if (ret < 0) {
 		LOG_DBG("Could not set ring indicator setting for sms");
 	}
 
-	snprintf(cmd_buffer, sizeof(cmd_buffer), "AT+QCFG=\"urc/ri/other\",\"%s\"",
-		gsm_ppp_get_ring_indicator_behaviour_text(other));
+	if (other == ALWAYS) {
+		LOG_ERR("Incorrect setting for other ring indicator, setting to OFF");
+		other = OFF;
+	}
+
+	gsm_ppp_generate_ring_indicator_at_cmd(cmd_buffer, sizeof(cmd_buffer),
+					       "urc/ri/other", other, other_pulse_duration);
 	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
-		&response_cmds[0], ARRAY_SIZE(response_cmds), cmd_buffer,
-		&gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
+				    &response_cmds[0], ARRAY_SIZE(response_cmds), cmd_buffer,
+				    &gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
 
 	if (ret < 0) {
 		LOG_DBG("Could not set ring indicator setting");

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -644,11 +644,9 @@ static void set_ppp_carrier_on(struct gsm_modem *gsm)
 	}
 }
 
-static void rssi_handler(struct k_work *work)
+static void request_rssi_value(struct gsm_modem *gsm)
 {
 	int ret;
-	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
-	struct gsm_modem *gsm = CONTAINER_OF(dwork, struct gsm_modem, rssi_work_handle);
 #if defined(CONFIG_MODEM_GSM_ENABLE_CESQ_RSSI)
 	ret = modem_cmd_send_nolock(&gsm->context.iface, &gsm->context.cmd_handler,
 		&read_rssi_cmd, 1, "AT+CESQ", &gsm->sem_response, GSM_CMD_SETUP_TIMEOUT);
@@ -660,6 +658,14 @@ static void rssi_handler(struct k_work *work)
 	if (ret < 0) {
 		LOG_DBG("No answer to RSSI readout, %s", "ignoring...");
 	}
+}
+
+static void rssi_handler(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gsm_modem *gsm = CONTAINER_OF(dwork, struct gsm_modem, rssi_work_handle);
+
+	request_rssi_value(gsm);
 
 	if (IS_ENABLED(CONFIG_GSM_MUX)) {
 #if defined(CONFIG_MODEM_CELL_INFO)
@@ -802,26 +808,24 @@ attaching:
 	gsm->rssi_retries = GSM_RSSI_RETRIES;
 	gsm->minfo.mdm_rssi = GSM_RSSI_INVALID;
 
- attached:
+attached:
 
-	if (!IS_ENABLED(CONFIG_GSM_MUX)) {
-		/* Read connection quality (RSSI) before PPP carrier is ON */
-		rssi_handler(&gsm->rssi_work_handle.work);
+	/* Read connection quality (RSSI) before PPP carrier is ON */
+	rssi_handler(&gsm->rssi_work_handle.work);
 
-		if (!(gsm->minfo.mdm_rssi && gsm->minfo.mdm_rssi != GSM_RSSI_INVALID &&
-			gsm->minfo.mdm_rssi < GSM_RSSI_MAXVAL)) {
+	if (!(gsm->minfo.mdm_rssi && gsm->minfo.mdm_rssi != GSM_RSSI_INVALID &&
+		gsm->minfo.mdm_rssi < GSM_RSSI_MAXVAL)) {
 
-			LOG_DBG("Not valid RSSI, %s", "retrying...");
-			if (gsm->rssi_retries-- > 0) {
-				(void)gsm_work_reschedule(&gsm->gsm_configure_work,
-							K_MSEC(GSM_RSSI_RETRY_DELAY_MSEC));
-				return;
-			}
+		LOG_DBG("Not valid RSSI, %s", "retrying...");
+		if (gsm->rssi_retries-- > 0) {
+			(void)gsm_work_reschedule(&gsm->gsm_configure_work,
+						K_MSEC(GSM_RSSI_RETRY_DELAY_MSEC));
+			return;
 		}
-#if defined(CONFIG_MODEM_CELL_INFO)
-		(void)gsm_query_cellinfo(gsm);
-#endif
 	}
+#if defined(CONFIG_MODEM_CELL_INFO)
+	(void)gsm_query_cellinfo(gsm);
+#endif
 
 	LOG_DBG("modem RSSI: %d, %s", gsm->minfo.mdm_rssi, "enable PPP");
 
@@ -1221,9 +1225,13 @@ void gsm_ppp_register_modem_power_callback(const struct device *dev,
 	gsm->user_data = user_data;
 }
 
-const struct gsm_ppp_modem_info *gsm_ppp_modem_info(const struct device *dev)
+const struct gsm_ppp_modem_info *gsm_ppp_modem_info(const struct device *dev, bool update_rssi)
 {
 	struct gsm_modem *gsm = dev->data;
+
+	if (update_rssi) {
+		request_rssi_value(gsm);
+	}
 
 	return &gsm->minfo;
 }

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -672,21 +672,3 @@ int modem_cmd_handler_init(struct modem_cmd_handler *handler,
 
 	return 0;
 }
-
-void modem_cmd_handler_disable_eol(struct modem_cmd_handler *handler)
-{
-	struct modem_cmd_handler_data *data;
-	data = (struct modem_cmd_handler_data *)(handler->cmd_handler_data);
-	data->eol_len = 0;
-}
-
-void modem_cmd_handler_restore_eol(struct modem_cmd_handler *handler)
-{
-	struct modem_cmd_handler_data *data;
-	data = (struct modem_cmd_handler_data *)(handler->cmd_handler_data);
-	if (data->eol == NULL) {
-		data->eol_len = 0;
-	} else {
-		data->eol_len = strlen(data->eol);
-	}
-}

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -87,6 +87,11 @@ struct modem_cmd {
 	MODEM_CMD(match_cmd_, func_cb_, num_param_, delim_) \
 }
 
+#define SETUP_CMD_ARGS_MAX(cmd_send_, match_cmd_, func_cb_, num_param_min, num_param_max, delim_) { \
+	.send_cmd = cmd_send_, \
+	MODEM_CMD_ARGS_MAX(match_cmd_, func_cb_, num_param_min, num_param_max, delim_) \
+}
+
 #define SETUP_CMD_NOHANDLE(send_cmd_) \
 		SETUP_CMD(send_cmd_, NULL, NULL, 0U, NULL)
 

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -301,17 +301,6 @@ int modem_cmd_handler_tx_lock(struct modem_cmd_handler *handler,
  */
 void modem_cmd_handler_tx_unlock(struct modem_cmd_handler *handler);
 
-/**
- * @brief  Disable the end of line character(s) after sending a command
- */
-void modem_cmd_handler_disable_eol(struct modem_cmd_handler *handler);
-
-/**
- * @brief  Restore the end of line character(s) after sending a command
- */
-void modem_cmd_handler_restore_eol(struct modem_cmd_handler *handler);
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/drivers/console/uart_mux.h
+++ b/include/zephyr/drivers/console/uart_mux.h
@@ -84,6 +84,8 @@ static inline int uart_mux_attach(const struct device *mux,
 	return api->attach(mux, uart, dlci_address, cb, user_data);
 }
 
+void uart_mux_disconnect(const struct device *dev, uint8_t dlci_address);
+
 /**
  * @brief Get UART related to a specific DLCI channel
  *

--- a/include/zephyr/drivers/modem/gsm_ppp.h
+++ b/include/zephyr/drivers/modem/gsm_ppp.h
@@ -26,6 +26,14 @@ struct gsm_ppp_modem_info {
 	int  mdm_rssi;
 };
 
+enum ring_indicator_behaviour {
+	OFF,
+	PULSE,
+	ALWAYS,
+	AUTO,
+	WAVE,
+};
+
 /** @cond INTERNAL_HIDDEN */
 struct device;
 typedef void (*gsm_modem_power_cb)(const struct device *, void *);
@@ -58,5 +66,10 @@ void gsm_ppp_register_modem_power_callback(const struct device *dev,
  * @retval struct gsm_ppp_modem_info * pointer to modem information structure.
  */
 const struct gsm_ppp_modem_info *gsm_ppp_modem_info(const struct device *dev);
+
+int gsm_ppp_set_ring_indicator(const struct device *dev,
+					   enum ring_indicator_behaviour ring,
+					   enum ring_indicator_behaviour other,
+					   enum ring_indicator_behaviour sms);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_GSM_PPP_H_ */

--- a/include/zephyr/drivers/modem/gsm_ppp.h
+++ b/include/zephyr/drivers/modem/gsm_ppp.h
@@ -81,10 +81,11 @@ void gsm_ppp_register_modem_power_callback(const struct device *dev,
  * @brief Get GSM modem information.
  *
  * @param dev: GSM modem device.
+ * @param update_rssi: Whether to update the rssi before obtaining the modem info.
  *
  * @retval struct gsm_ppp_modem_info * pointer to modem information structure.
  */
-const struct gsm_ppp_modem_info *gsm_ppp_modem_info(const struct device *dev);
+const struct gsm_ppp_modem_info *gsm_ppp_modem_info(const struct device *dev, bool update_rssi);
 
 /**
  * @brief Set modem ring indicator behaviour.

--- a/include/zephyr/drivers/modem/gsm_ppp.h
+++ b/include/zephyr/drivers/modem/gsm_ppp.h
@@ -32,7 +32,7 @@ typedef void (*gsm_modem_power_cb)(const struct device *, void *);
 
 void gsm_ppp_start(const struct device *dev);
 void gsm_ppp_recover_cmux(const struct device *dev);
-void gsm_ppp_stop(const struct device *dev);
+void gsm_ppp_stop(const struct device *dev, bool keep_AT_channel);
 /** @endcond */
 
 /**

--- a/include/zephyr/drivers/modem/gsm_ppp.h
+++ b/include/zephyr/drivers/modem/gsm_ppp.h
@@ -49,8 +49,6 @@ enum ring_indicator_behaviour {
 	OFF,
 	PULSE,
 	ALWAYS,
-	AUTO,
-	WAVE,
 };
 
 /** @cond INTERNAL_HIDDEN */
@@ -92,13 +90,19 @@ const struct gsm_ppp_modem_info *gsm_ppp_modem_info(const struct device *dev, bo
  *
  * @param dev: GSM modem device.
  * @param ring: Ring indicator behaviour when ring is presented.
+ * @param ring_pulse_duration: Ring indicator pulse duration when ring behavior set to pulse.
  * @param sms: Ring indicator behaviour when SMS is presented.
+ * @param sms_pulse_duration: SMS indicator pulse duration when SMS behavior set to pulse.
  * @param other: Ring indicator behaviour when other is presented.
+ * @param other_pulse_duration: Other indicator pulse duration when other behavior set to pulse.
  */
 void gsm_ppp_set_ring_indicator(const struct device *dev,
-					   enum ring_indicator_behaviour ring,
-					   enum ring_indicator_behaviour sms,
-					   enum ring_indicator_behaviour other);
+				enum ring_indicator_behaviour ring,
+				uint16_t ring_pulse_duration,
+				enum ring_indicator_behaviour sms,
+				uint16_t sms_pulse_duration,
+				enum ring_indicator_behaviour other,
+				uint16_t other_pulse_duration);
 
 /**
  * @brief Configure modem for receiving SMS messages.

--- a/include/zephyr/drivers/modem/gsm_ppp.h
+++ b/include/zephyr/drivers/modem/gsm_ppp.h
@@ -70,12 +70,15 @@ void gsm_ppp_stop(const struct device *dev, bool keep_AT_channel);
  * @param dev: gsm modem device
  * @param modem_on: callback function to
  *		execute during gsm ppp configuring.
+ * @param modem_configured: callback function to
+ *		execute when modem is configured.
  * @param modem_off: callback function to
  *		execute during gsm ppp stopping.
  * @param user_data: user specified data
  */
 void gsm_ppp_register_modem_power_callback(const struct device *dev,
 					   gsm_modem_power_cb modem_on,
+					   gsm_modem_power_cb modem_configured,
 					   gsm_modem_power_cb modem_off,
 					   void *user_data);
 

--- a/include/zephyr/drivers/modem/gsm_ppp.h
+++ b/include/zephyr/drivers/modem/gsm_ppp.h
@@ -115,4 +115,18 @@ void gsm_ppp_configure_sms_reception(const struct device *dev);
  */
 struct gsm_ppp_sms_message * gsm_ppp_read_sms(const struct device *dev);
 
+/**
+ * @brief Delete all SMS messages from the modem storage.
+ *
+ * @param dev: GSM modem device.
+ */
+void gsm_ppp_delete_all_sms(const struct device *dev);
+
+/**
+ * @brief Clear the ring indicator of the modem.
+ *
+ * @param dev: GSM modem device.
+ */
+void gsm_ppp_clear_ring_indicator(const struct device *dev);
+
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_GSM_PPP_H_ */

--- a/include/zephyr/drivers/modem/gsm_ppp.h
+++ b/include/zephyr/drivers/modem/gsm_ppp.h
@@ -14,12 +14,14 @@
 #define GSM_PPP_MDM_IMSI_LENGTH          16
 #define GSM_PPP_MDM_ICCID_LENGTH         32
 
+#if defined(CONFIG_MODEM_GMS_ENABLE_SMS)
 #define GSM_PPP_SMS_STATUS_LENGTH        16
 #define GSM_PPP_SMS_OA_LENGTH            16
 #define GSM_PPP_SMS_OA_NAME_LENGTH       32
 #define GSM_PPP_SMS_DATE_LENGTH          16
 #define GSM_PPP_SMS_TIME_LENGTH          16
 #define GSM_PPP_SMS_DATA_LENGTH         180
+#endif
 
 struct gsm_ppp_modem_info {
 	char mdm_manufacturer[GSM_PPP_MDM_MANUFACTURER_LENGTH];
@@ -33,6 +35,7 @@ struct gsm_ppp_modem_info {
 	int  mdm_rssi;
 };
 
+#if defined(CONFIG_MODEM_GMS_ENABLE_SMS)
 struct gsm_ppp_sms_message {
 	bool valid;
 	bool has_data;
@@ -50,6 +53,7 @@ enum ring_indicator_behaviour {
 	PULSE,
 	ALWAYS,
 };
+#endif
 
 /** @cond INTERNAL_HIDDEN */
 struct device;
@@ -85,6 +89,7 @@ void gsm_ppp_register_modem_power_callback(const struct device *dev,
  */
 const struct gsm_ppp_modem_info *gsm_ppp_modem_info(const struct device *dev, bool update_rssi);
 
+#if defined(CONFIG_MODEM_GMS_ENABLE_SMS)
 /**
  * @brief Set modem ring indicator behaviour.
  *
@@ -133,5 +138,6 @@ void gsm_ppp_delete_all_sms(const struct device *dev);
  * @param dev: GSM modem device.
  */
 void gsm_ppp_clear_ring_indicator(const struct device *dev);
+#endif /* defined(CONFIG_MODEM_GMS_ENABLE_SMS) */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_GSM_PPP_H_ */

--- a/include/zephyr/drivers/modem/gsm_ppp.h
+++ b/include/zephyr/drivers/modem/gsm_ppp.h
@@ -14,6 +14,13 @@
 #define GSM_PPP_MDM_IMSI_LENGTH          16
 #define GSM_PPP_MDM_ICCID_LENGTH         32
 
+#define GSM_PPP_SMS_STATUS_LENGTH        16
+#define GSM_PPP_SMS_OA_LENGTH            16
+#define GSM_PPP_SMS_OA_NAME_LENGTH       32
+#define GSM_PPP_SMS_DATE_LENGTH          16
+#define GSM_PPP_SMS_TIME_LENGTH          16
+#define GSM_PPP_SMS_DATA_LENGTH         180
+
 struct gsm_ppp_modem_info {
 	char mdm_manufacturer[GSM_PPP_MDM_MANUFACTURER_LENGTH];
 	char mdm_model[GSM_PPP_MDM_MODEL_LENGTH];
@@ -24,6 +31,18 @@ struct gsm_ppp_modem_info {
 	char mdm_iccid[GSM_PPP_MDM_ICCID_LENGTH];
 #endif
 	int  mdm_rssi;
+};
+
+struct gsm_ppp_sms_message {
+	bool valid;
+	bool has_data;
+	int index;
+	char status[GSM_PPP_SMS_STATUS_LENGTH];
+	char origin_address[GSM_PPP_SMS_OA_LENGTH];
+	char origin_name[GSM_PPP_SMS_OA_NAME_LENGTH];
+	char date[GSM_PPP_SMS_DATE_LENGTH];
+	char time[GSM_PPP_SMS_TIME_LENGTH];
+	char data[GSM_PPP_SMS_DATA_LENGTH];
 };
 
 enum ring_indicator_behaviour {
@@ -91,7 +110,9 @@ void gsm_ppp_configure_sms_reception(const struct device *dev);
  * @brief Read a SMS message from the modem.
  *
  * @param dev: GSM modem device.
+ *
+ * @retval struct gsm_ppp_sms_message * pointer to the received SMS information
  */
-void gsm_ppp_read_sms(const struct device *dev);
+struct gsm_ppp_sms_message * gsm_ppp_read_sms(const struct device *dev);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_GSM_PPP_H_ */

--- a/include/zephyr/drivers/modem/gsm_ppp.h
+++ b/include/zephyr/drivers/modem/gsm_ppp.h
@@ -67,9 +67,31 @@ void gsm_ppp_register_modem_power_callback(const struct device *dev,
  */
 const struct gsm_ppp_modem_info *gsm_ppp_modem_info(const struct device *dev);
 
-int gsm_ppp_set_ring_indicator(const struct device *dev,
+/**
+ * @brief Set modem ring indicator behaviour.
+ *
+ * @param dev: GSM modem device.
+ * @param ring: Ring indicator behaviour when ring is presented.
+ * @param sms: Ring indicator behaviour when SMS is presented.
+ * @param other: Ring indicator behaviour when other is presented.
+ */
+void gsm_ppp_set_ring_indicator(const struct device *dev,
 					   enum ring_indicator_behaviour ring,
-					   enum ring_indicator_behaviour other,
-					   enum ring_indicator_behaviour sms);
+					   enum ring_indicator_behaviour sms,
+					   enum ring_indicator_behaviour other);
+
+/**
+ * @brief Configure modem for receiving SMS messages.
+ *
+ * @param dev: GSM modem device.
+ */
+void gsm_ppp_configure_sms_reception(const struct device *dev);
+
+/**
+ * @brief Read a SMS message from the modem.
+ *
+ * @param dev: GSM modem device.
+ */
+void gsm_ppp_read_sms(const struct device *dev);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MODEM_GSM_PPP_H_ */


### PR DESCRIPTION
In order to support the remote wakeup SMS message, the GSM driver required some changes. First off all, a bunch of code to sent the specific AT commands to setup the modem for SMS reception and furthermore, when the modem signals it has received an SMS message, to read it.

However this required that the CMUX connection to the modem would be disabled in the mean time. Therefore, a lot of changes are made to ensure the CMUX connection is properly closed when the `gsm_ppp_stop` function is called. This does result in a still working AT channel over UART on which other AT commands can be send.