### PR TITLE
DECO-137 - Sync system clock

### DIFF
--- a/include/zephyr/drivers/rtc/stm32_rtc.h
+++ b/include/zephyr/drivers/rtc/stm32_rtc.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Sensorfy
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Real-time clock control based on the STM32 internal RTC.
+ *
+ * The core Zephyr API to this device is as a counter.
+ *
+ * Additional implementation details a user should take into account:
+ * * The STM32 counter must be initialized before using the set time
+ *   function below
+ */
+#ifndef ZEPHYR_INCLUDE_DRIVERS_RTC_STM32_H_
+#define ZEPHYR_INCLUDE_DRIVERS_RTC_STM32_H_
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Set the current counter value
+ *
+ * As the counter advances at 1Hz this will usually be set to the
+ * current UNIX time stamp.
+ *
+ * @param dev the STM32 RTC device pointer.
+ *
+ * @param ticks the new value of the internal counter
+ *
+ * @retval non-negative on success
+ */
+int rtc_stm32_set_value(const struct device *dev, uint32_t ticks);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_RTC_STM32_H_ */

--- a/include/zephyr/net/sntp.h
+++ b/include/zephyr/net/sntp.h
@@ -15,6 +15,7 @@
 #include <zephyr/posix/unistd.h>
 #include <zephyr/posix/poll.h>
 #endif
+#include <zephyr/posix/time.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/net/sntp.h
+++ b/include/zephyr/net/sntp.h
@@ -96,6 +96,22 @@ void sntp_close(struct sntp_ctx *ctx);
 int sntp_simple(const char *server, uint32_t timeout,
 		struct sntp_time *time);
 
+#if defined(CONFIG_POSIX_CLOCK)
+/**
+ * @brief Convenience function to query SNTP and set system time
+ * in one-shot fashion
+ *
+ * Convenience wrapper which calls getaddrinfo(), sntp_init(),
+ * sntp_query(), sntp_close(), and clock_settime().
+ *
+ * @param server Address of server in format addr[:port]
+ * @param timeout Query timeout
+ *
+ * @return 0 if ok, <0 if error (-ETIMEDOUT if timeout).
+ */
+int sntp_set_system_time(const char *server, uint32_t timeout);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/net/sntp.h
+++ b/include/zephyr/net/sntp.h
@@ -96,7 +96,16 @@ void sntp_close(struct sntp_ctx *ctx);
 int sntp_simple(const char *server, uint32_t timeout,
 		struct sntp_time *time);
 
-#if defined(CONFIG_POSIX_CLOCK)
+/**
+ * @brief Convert SNTP time struncture to the POSIX time struncture
+ *
+ * @param ts SNTP time structure obtained from SNTP query
+ * @param tspec POSIX time structure that will contain the converted time
+ */
+void sntp_convert_time(struct sntp_time * ts,
+		       struct timespec * tspec);
+
+#if defined(CONFIG_SNTP_SET_SYSTEM_TIME)
 /**
  * @brief Convenience function to query SNTP and set system time
  * in one-shot fashion

--- a/subsys/net/lib/config/init_clock_sntp.c
+++ b/subsys/net/lib/config/init_clock_sntp.c
@@ -13,19 +13,13 @@ LOG_MODULE_DECLARE(net_config, CONFIG_NET_CONFIG_LOG_LEVEL);
 
 int net_init_clock_via_sntp(void)
 {
-	struct sntp_time ts;
-	struct timespec tspec;
-	int res = sntp_simple(CONFIG_NET_CONFIG_SNTP_INIT_SERVER,
-			      CONFIG_NET_CONFIG_SNTP_INIT_TIMEOUT, &ts);
+	int res = sntp_set_system_time(CONFIG_NET_CONFIG_SNTP_INIT_SERVER,
+				       CONFIG_NET_CONFIG_SNTP_INIT_TIMEOUT);
 
 	if (res < 0) {
 		LOG_ERR("Cannot set time using SNTP");
 		return res;
 	}
-
-	tspec.tv_sec = ts.seconds;
-	tspec.tv_nsec = ((uint64_t)ts.fraction * (1000 * 1000 * 1000)) >> 32;
-	res = clock_settime(CLOCK_REALTIME, &tspec);
 
 	return 0;
 }

--- a/subsys/net/lib/sntp/Kconfig
+++ b/subsys/net/lib/sntp/Kconfig
@@ -16,4 +16,11 @@ module-str = Log level for SNTP
 module-help = Enable debug message of SNTP client library.
 source "subsys/net/Kconfig.template.log_config.net"
 
+menuconfig SNTP_SET_SYSTEM_TIME
+	bool "SNTP set system time"
+	depends on POSIX_CLOCK
+	help
+	  Enable the function to set the system time
+	  based on the SNTP return value
+
 endif # SNTP

--- a/subsys/net/lib/sntp/sntp_simple.c
+++ b/subsys/net/lib/sntp/sntp_simple.c
@@ -7,7 +7,7 @@
 
 #include <zephyr/net/sntp.h>
 #include <zephyr/net/socketutils.h>
-#if defined(CONFIG_POSIX_CLOCK)
+#if defined(CONFIG_SNTP_SET_SYSTEM_TIME)
 #include <zephyr/posix/time.h>
 #endif
 
@@ -69,7 +69,7 @@ freeaddr:
 	return res;
 }
 
-#if defined(CONFIG_POSIX_CLOCK)
+#if defined(CONFIG_SNTP_SET_SYSTEM_TIME)
 int sntp_set_system_time(const char *server, uint32_t timeout)
 {
 	struct sntp_time ts;

--- a/subsys/net/lib/sntp/sntp_simple.c
+++ b/subsys/net/lib/sntp/sntp_simple.c
@@ -7,7 +7,9 @@
 
 #include <zephyr/net/sntp.h>
 #include <zephyr/net/socketutils.h>
+#if defined(CONFIG_POSIX_CLOCK)
 #include <zephyr/posix/time.h>
+#endif
 
 int sntp_simple(const char *server, uint32_t timeout, struct sntp_time *time)
 {

--- a/subsys/net/lib/sntp/sntp_simple.c
+++ b/subsys/net/lib/sntp/sntp_simple.c
@@ -7,9 +7,7 @@
 
 #include <zephyr/net/sntp.h>
 #include <zephyr/net/socketutils.h>
-#if defined(CONFIG_SNTP_SET_SYSTEM_TIME)
 #include <zephyr/posix/time.h>
-#endif
 
 int sntp_simple(const char *server, uint32_t timeout, struct sntp_time *time)
 {

--- a/subsys/net/lib/sntp/sntp_simple.c
+++ b/subsys/net/lib/sntp/sntp_simple.c
@@ -69,6 +69,12 @@ freeaddr:
 	return res;
 }
 
+void sntp_convert_time(struct sntp_time * ts, struct timespec * tspec)
+{
+	tspec->tv_sec = ts->seconds;
+	tspec->tv_nsec = ((uint64_t)ts->fraction * (1000 * 1000 * 1000)) >> 32;
+}
+
 #if defined(CONFIG_SNTP_SET_SYSTEM_TIME)
 int sntp_set_system_time(const char *server, uint32_t timeout)
 {
@@ -80,8 +86,7 @@ int sntp_set_system_time(const char *server, uint32_t timeout)
 		return res;
 	}
 
-	tspec.tv_sec = ts.seconds;
-	tspec.tv_nsec = ((uint64_t)ts.fraction * (1000 * 1000 * 1000)) >> 32;
+	sntp_convert_time(&ts, &tspec);
 	res = clock_settime(CLOCK_REALTIME, &tspec);
 
 	if (res < 0) {

--- a/subsys/net/lib/sntp/sntp_simple.c
+++ b/subsys/net/lib/sntp/sntp_simple.c
@@ -84,6 +84,10 @@ int sntp_set_system_time(const char *server, uint32_t timeout)
 	tspec.tv_nsec = ((uint64_t)ts.fraction * (1000 * 1000 * 1000)) >> 32;
 	res = clock_settime(CLOCK_REALTIME, &tspec);
 
+	if (res < 0) {
+		return res;
+	}
+
 	return 0;
 }
 #endif


### PR DESCRIPTION
- Found a hidden function which deep in Zephyr that sets the Posix system clock after an SNTP update. It was not included in any header file and, when enabling its own config option `CONFIG_NET_CONFIG_CLOCK_SNTP_INIT`, it was not even compiled. Therefore, it was moved to the SNTP library for convenience.
- The STM32 counter from Zephyr is implemented using the Real Time Clock on the chip. Although, the counter drivers in Zephyr do not provide the functionality to set the time. A function to do so was added in the same way as done by the `mcp7940` or `IMX SNVS RTC` real time clocks that use the Zephyr counter implementation as well.