### PR TITLE
DECO Remove compile warnings

### DIFF
--- a/dts/bindings/mtd/fixed-partitions.yaml
+++ b/dts/bindings/mtd/fixed-partitions.yaml
@@ -20,6 +20,10 @@ child-binding:
           type: string
           required: false
           description: Human readable string describing the device (used as device_get_binding() argument)
+       partition-name:
+          type: string
+          required: false
+          description: Same as label, but as label is deprecated since Zephyr v3.2, this is to reduce compilation warnings
        read-only:
           type: boolean
           required: false

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -311,6 +311,16 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
 #define FIXED_PARTITION_SIZE(label) DT_REG_SIZE(DT_NODELABEL(label))
 
 /**
+ * Get fixed-partition name for DTS node label
+ *
+ * @param label DTS node label
+ *
+ * @return fixed-partition name, as defined for the partition in DTS.
+ */
+#define FIXED_PARTITION_NAME(label) \
+	DT_PROP_OR(label, partition_name, DT_NODE_FULL_NAME(label))
+
+/**
  * Get device pointer for device the area/partition resides on
  *
  * @param label DTS node label of a partition

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -15,7 +15,7 @@
 	{.fa_id = DT_FIXED_PARTITION_ID(part),					\
 	 .fa_off = DT_REG_ADDR(part),						\
 	 .fa_dev = DEVICE_DT_GET_OR_NULL(DT_MTD_FROM_FIXED_PARTITION(part)),	\
-	 .fa_label = DEVICE_DT_NAME(part),					\
+	 .fa_label = FIXED_PARTITION_NAME(part),				\
 	 .fa_size = DT_REG_SIZE(part),},
 
 #define FOREACH_PARTITION(n) DT_FOREACH_CHILD(DT_DRV_INST(n), FLASH_AREA_FOO)

--- a/subsys/storage/flash_map/flash_map_shell.c
+++ b/subsys/storage/flash_map/flash_map_shell.c
@@ -33,7 +33,7 @@ static int cmd_flash_map_list(const struct shell *shell, size_t argc,
 			      char **argv)
 {
 	shell_print(shell, "ID | Device | Device Name        "
-		    "| Label              | Offset     | Size");
+		    "| Name               | Offset     | Size");
 	shell_print(shell, "---------------------------------"
 		    "---------------------------------------------");
 	flash_area_foreach(fa_cb, (struct shell *)shell);


### PR DESCRIPTION
Ssince Zephyr v3.2 the label property in the device tree has become deprecated. Nevertheless, for the fixed partitions the label is still used. This leads to compilation warnings in the DECO project.

In this PR a new property is added to a fixed partition to set the partition name. It is the same as the label, but does not lead to compile warnings.
The label is not yet removed as it is unclear if Zephyr will fix the problem for the fixed partition label in the near future, or also replace it with a new property. Furthermore, it will work backwards compatible for other projects using this branch based on other architectures which still have device trees with the label in them.