### PR TITLE
DECO-200 - Event data JSON encoding

### DIFF
--- a/include/zephyr/data/json.h
+++ b/include/zephyr/data/json.h
@@ -45,6 +45,7 @@ enum json_tokens {
 	JSON_TOK_LIST_END __deprecated = ']',
 	JSON_TOK_ARRAY_END = ']',
 	JSON_TOK_STRING = '"',
+	JSON_TOK_ASCII = 'a',
 	JSON_TOK_COLON = ':',
 	JSON_TOK_COMMA = ',',
 	JSON_TOK_NUMBER = '0',

--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -1145,6 +1145,12 @@ static int arr_encode(const struct json_obj_descr *elem_descr,
 	return append_bytes("]", 1, data);
 }
 
+static int ascii_encode(const char **str, json_append_bytes_t append_bytes,
+			void *data)
+{
+	return append_bytes(*str, strlen(*str), data);
+}
+
 static int str_encode(const char **str, json_append_bytes_t append_bytes,
 		      void *data)
 {
@@ -1275,6 +1281,8 @@ static int encode(const struct json_obj_descr *descr, const void *val,
 		return bool_encode(ptr, append_bytes, data);
 	case JSON_TOK_STRING:
 		return str_encode(ptr, append_bytes, data);
+	case JSON_TOK_ASCII:
+		return ascii_encode(ptr, append_bytes, data);
 	case JSON_TOK_ARRAY_START:
 		return arr_encode(descr->array.element_descr, ptr,
 				  val, append_bytes, data);


### PR DESCRIPTION
 Add support to add a JSON ascii object to the ascii encoder. This allows to pass a string that does not get escaped or quoted but is inserted into the resulting JSON completely untouched.