### PR TITLE
DECO-173 Set RI to physical because the default does not work.

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1657,6 +1657,8 @@ void gsm_ppp_set_ring_indicator(const struct device *dev,
 static const struct setup_cmd sms_configure_cmds[] = {
 	/* Set SMS message format to text */
 	SETUP_CMD_NOHANDLE("AT+CMGF=1"),
+	/* Configure the RI to be the physical port */
+	SETUP_CMD_NOHANDLE("AT+QCFG=\"risignaltype\",\"physical\""),
 	/* Set SMS message reporting to message the receiver */
 	SETUP_CMD_NOHANDLE("AT+CNMI=2,1"),
 	/* Set SMS message character set */


### PR DESCRIPTION
Seems that a command was missing which I suspect is non-volatile in the BG96. So probably during development, it worked, but after a factory reset, I might not have worked.

	/* Configure the RI to be the physical port */
	SETUP_CMD_NOHANDLE("AT+QCFG=\"risignaltype\",\"physical\""),