### PR TITLE
IACS-586

### DIFF
--- a/drivers/console/gsm_mux.c
+++ b/drivers/console/gsm_mux.c
@@ -735,17 +735,17 @@ int gsm_mux_disconnect(struct gsm_mux *mux, uint8_t dlci_address, k_timeout_t ti
 
 	int err = gsm_mux_send_control_message(dlci->mux, dlci->num,
 					       CMD_CLD, NULL, 0);
-	if (err != 0) {
+	if (err < 0) {
 		LOG_WRN("gsm_mux_disconnect(): Send control message failed (err: %d).", err);
 	}
 
 	err = k_work_cancel_delayable(&mux->t2_timer);
-	if (err != 0) {
+	if (err < 0) {
 		LOG_WRN("gsm_mux_disconnect(): Failed cancelling delayed timer work (err: %d).", err);
 	}
 
 	err = gsm_dlci_closing(dlci, NULL);
-	if (err != 0) {
+	if (err < 0) {
 		LOG_WRN("gsm_mux_disconnect(): Failed closing GSM DLCI (err: %d).", err);
 	}
 

--- a/drivers/console/gsm_mux.c
+++ b/drivers/console/gsm_mux.c
@@ -729,15 +729,25 @@ int gsm_mux_disconnect(struct gsm_mux *mux, uint8_t dlci_address, k_timeout_t ti
 
 	dlci = gsm_dlci_get(mux, dlci_address);
 	if (dlci == NULL) {
+		LOG_ERR("gsm_mux_disconnect(): DLCI \"get\" returned NULL for address %u.", dlci_address);
 		return -ENOENT;
 	}
 
-	(void)gsm_mux_send_control_message(dlci->mux, dlci->num,
-					   CMD_CLD, NULL, 0);
+	int err = gsm_mux_send_control_message(dlci->mux, dlci->num,
+					       CMD_CLD, NULL, 0);
+	if (err != 0) {
+		LOG_WRN("gsm_mux_disconnect(): Send control message failed (err: %d).", err);
+	}
 
-	(void)k_work_cancel_delayable(&mux->t2_timer);
+	err = k_work_cancel_delayable(&mux->t2_timer);
+	if (err != 0) {
+		LOG_WRN("gsm_mux_disconnect(): Failed cancelling delayed timer work (err: %d).", err);
+	}
 
-	(void)gsm_dlci_closing(dlci, NULL);
+	err = gsm_dlci_closing(dlci, NULL);
+	if (err != 0) {
+		LOG_WRN("gsm_mux_disconnect(): Failed closing GSM DLCI (err: %d).", err);
+	}
 
 	return k_sem_take(&dlci->disconnect_sem, timeout);
 }

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -90,7 +90,7 @@ static struct gsm_modem {
 		GSM_PPP_WAIT_AT,
 		GSM_PPP_AT_RDY,
 		GSM_PPP_STATE_INIT,
-		GSM_PPP_STATE_CONTROL_CHANNEL = GSM_PPP_STATE_INIT,
+		GSM_PPP_STATE_CONTROL_CHANNEL,
 		GSM_PPP_STATE_PPP_CHANNEL,
 		GSM_PPP_STATE_AT_CHANNEL,
 		GSM_PPP_STATE_DONE,
@@ -1291,14 +1291,26 @@ static void mux_setup(struct k_work *work)
 	gsm_ppp_lock(gsm);
 
 	switch (gsm->state) {
-	case GSM_PPP_STATE_CONTROL_CHANNEL:
-		/* We need to call this to reactivate mux ISR. Note: This is only called
-		 * after re-initing gsm_ppp.
+	case GSM_PPP_STATE_INIT:
+		/* We need to call uart_mux_enable to reactivate mux ISR.
+		 * Note: This is only called after re-initing gsm_ppp.
 		 */
 		if (gsm->ppp_dev != NULL) {
 			uart_mux_enable(gsm->ppp_dev);
 		}
+		if (gsm->at_dev != NULL) {
+			uart_mux_enable(gsm->at_dev);
+		}
+		if (gsm->control_dev != NULL) {
+			uart_mux_enable(gsm->control_dev);
+		}
 
+		gsm->state = GSM_PPP_STATE_CONTROL_CHANNEL;
+		gsm_ppp_unlock(gsm);
+		mux_setup_next(gsm);
+
+		return;
+	case GSM_PPP_STATE_CONTROL_CHANNEL:
 		/* Get UART device. There is one dev / DLCI */
 		if (gsm->control_dev == NULL) {
 			gsm->control_dev = uart_mux_alloc();
@@ -1383,6 +1395,46 @@ fail:
 	gsm->state = GSM_PPP_STATE_ERROR;
 unlock:
 	gsm_ppp_unlock(gsm);
+}
+
+void mux_disable(struct gsm_modem *gsm)
+{
+	int r;
+	if (IS_ENABLED(CONFIG_GSM_MUX)) {
+		if (gsm->at_dev) {
+			int err = uart_mux_disconnect(gsm->at_dev, DLCI_AT, K_FOREVER);
+			if (err != 0) {
+				LOG_WRN("mux_disable(): UART mux disable returned %d for AT device.", err);
+			}
+		}
+		if (gsm->ppp_dev) {
+			int err = uart_mux_disconnect(gsm->ppp_dev, DLCI_PPP, K_FOREVER);
+			if (err != 0) {
+				LOG_WRN("mux_disable(): UART mux disable returned %d for PPP device.", err);
+			}
+		}
+		if (gsm->control_dev) {
+			int err = uart_mux_disconnect(gsm->control_dev, DLCI_CONTROL, K_FOREVER);
+			if (err != 0) {
+				LOG_WRN("mux_disable(): UART mux disable returned %d for CONTROL device.", err);
+			}
+		}
+		if (gsm->at_dev) {
+			uart_mux_disable(gsm->at_dev);
+		}
+		if (gsm->ppp_dev) {
+			uart_mux_disable(gsm->ppp_dev);
+		}
+		if (gsm->control_dev) {
+			uart_mux_disable(gsm->control_dev);
+		}
+		gsm->state = GSM_PPP_STATE_ERROR;
+		r = modem_iface_uart_init_dev(&gsm->context.iface,
+					      DEVICE_DT_GET(GSM_UART_NODE));
+		if (r) {
+			LOG_ERR("modem_iface_uart_init returned %d", r);
+		}
+	}
 }
 
 static void gsm_configure(struct k_work *work)
@@ -1499,12 +1551,8 @@ void gsm_ppp_recover_cmux(const struct device *dev)
 
 	gsm_ppp_cancel(gsm);
 
-	gsm_ppp_lock(gsm);
-
 	if (IS_ENABLED(CONFIG_GSM_MUX)) {
-		if (gsm->ppp_dev != NULL) {
-			uart_mux_disable(gsm->ppp_dev);
-		}
+		mux_disable(gsm);
 	}
 
 	gsm->state = GSM_PPP_STOP;
@@ -1531,15 +1579,13 @@ void gsm_ppp_stop(const struct device *dev, bool keep_AT_channel)
 	}
 
 	if (IS_ENABLED(CONFIG_GSM_MUX)) {
-		if (gsm->ppp_dev != NULL) {
-			uart_mux_disable(gsm->ppp_dev);
-		}
+		mux_disable(gsm);
+	}
 
-		if (!keep_AT_channel) {
-			if (modem_cmd_handler_tx_lock(&gsm->context.cmd_handler,
-									GSM_CMD_LOCK_TIMEOUT) < 0) {
-				LOG_WRN("Failed locking modem cmds!");
-			}
+	if (!keep_AT_channel) {
+		if (modem_cmd_handler_tx_lock(&gsm->context.cmd_handler,
+								GSM_CMD_LOCK_TIMEOUT) < 0) {
+			LOG_WRN("Failed locking modem cmds!");
 		}
 	}
 

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -90,7 +90,7 @@ static struct gsm_modem {
 		GSM_PPP_WAIT_AT,
 		GSM_PPP_AT_RDY,
 		GSM_PPP_STATE_INIT,
-		GSM_PPP_STATE_CONTROL_CHANNEL,
+		GSM_PPP_STATE_CONTROL_CHANNEL = GSM_PPP_STATE_INIT,
 		GSM_PPP_STATE_PPP_CHANNEL,
 		GSM_PPP_STATE_AT_CHANNEL,
 		GSM_PPP_STATE_DONE,
@@ -1291,26 +1291,14 @@ static void mux_setup(struct k_work *work)
 	gsm_ppp_lock(gsm);
 
 	switch (gsm->state) {
-	case GSM_PPP_STATE_INIT:
-		/* We need to call uart_mux_enable to reactivate mux ISR.
-		 * Note: This is only called after re-initing gsm_ppp.
+	case GSM_PPP_STATE_CONTROL_CHANNEL:
+		/* We need to call this to reactivate mux ISR. Note: This is only called
+		 * after re-initing gsm_ppp.
 		 */
 		if (gsm->ppp_dev != NULL) {
 			uart_mux_enable(gsm->ppp_dev);
 		}
-		if (gsm->at_dev != NULL) {
-			uart_mux_enable(gsm->at_dev);
-		}
-		if (gsm->control_dev != NULL) {
-			uart_mux_enable(gsm->control_dev);
-		}
 
-		gsm->state = GSM_PPP_STATE_CONTROL_CHANNEL;
-		gsm_ppp_unlock(gsm);
-		mux_setup_next(gsm);
-
-		return;
-	case GSM_PPP_STATE_CONTROL_CHANNEL:
 		/* Get UART device. There is one dev / DLCI */
 		if (gsm->control_dev == NULL) {
 			gsm->control_dev = uart_mux_alloc();
@@ -1395,46 +1383,6 @@ fail:
 	gsm->state = GSM_PPP_STATE_ERROR;
 unlock:
 	gsm_ppp_unlock(gsm);
-}
-
-void mux_disable(struct gsm_modem *gsm)
-{
-	int r;
-	if (IS_ENABLED(CONFIG_GSM_MUX)) {
-		if (gsm->at_dev) {
-			int err = uart_mux_disconnect(gsm->at_dev, DLCI_AT, K_FOREVER);
-			if (err != 0) {
-				LOG_WRN("mux_disable(): UART mux disable returned %d for AT device.", err);
-			}
-		}
-		if (gsm->ppp_dev) {
-			int err = uart_mux_disconnect(gsm->ppp_dev, DLCI_PPP, K_FOREVER);
-			if (err != 0) {
-				LOG_WRN("mux_disable(): UART mux disable returned %d for PPP device.", err);
-			}
-		}
-		if (gsm->control_dev) {
-			int err = uart_mux_disconnect(gsm->control_dev, DLCI_CONTROL, K_FOREVER);
-			if (err != 0) {
-				LOG_WRN("mux_disable(): UART mux disable returned %d for CONTROL device.", err);
-			}
-		}
-		if (gsm->at_dev) {
-			uart_mux_disable(gsm->at_dev);
-		}
-		if (gsm->ppp_dev) {
-			uart_mux_disable(gsm->ppp_dev);
-		}
-		if (gsm->control_dev) {
-			uart_mux_disable(gsm->control_dev);
-		}
-		gsm->state = GSM_PPP_STATE_ERROR;
-		r = modem_iface_uart_init_dev(&gsm->context.iface,
-					      DEVICE_DT_GET(GSM_UART_NODE));
-		if (r) {
-			LOG_ERR("modem_iface_uart_init returned %d", r);
-		}
-	}
 }
 
 static void gsm_configure(struct k_work *work)
@@ -1551,8 +1499,12 @@ void gsm_ppp_recover_cmux(const struct device *dev)
 
 	gsm_ppp_cancel(gsm);
 
+	gsm_ppp_lock(gsm);
+
 	if (IS_ENABLED(CONFIG_GSM_MUX)) {
-		mux_disable(gsm);
+		if (gsm->ppp_dev != NULL) {
+			uart_mux_disable(gsm->ppp_dev);
+		}
 	}
 
 	gsm->state = GSM_PPP_STOP;
@@ -1579,13 +1531,15 @@ void gsm_ppp_stop(const struct device *dev, bool keep_AT_channel)
 	}
 
 	if (IS_ENABLED(CONFIG_GSM_MUX)) {
-		mux_disable(gsm);
-	}
+		if (gsm->ppp_dev != NULL) {
+			uart_mux_disable(gsm->ppp_dev);
+		}
 
-	if (!keep_AT_channel) {
-		if (modem_cmd_handler_tx_lock(&gsm->context.cmd_handler,
-								GSM_CMD_LOCK_TIMEOUT) < 0) {
-			LOG_WRN("Failed locking modem cmds!");
+		if (!keep_AT_channel) {
+			if (modem_cmd_handler_tx_lock(&gsm->context.cmd_handler,
+									GSM_CMD_LOCK_TIMEOUT) < 0) {
+				LOG_WRN("Failed locking modem cmds!");
+			}
 		}
 	}
 

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1402,13 +1402,22 @@ void mux_disable(struct gsm_modem *gsm)
 	int r;
 	if (IS_ENABLED(CONFIG_GSM_MUX)) {
 		if (gsm->at_dev) {
-			(void)uart_mux_disconnect(gsm->at_dev, DLCI_AT, K_FOREVER);
+			int err = uart_mux_disconnect(gsm->at_dev, DLCI_AT, K_FOREVER);
+			if (err != 0) {
+				LOG_WRN("mux_disable(): UART mux disable returned %d for AT device.", err);
+			}
 		}
 		if (gsm->ppp_dev) {
-			(void)uart_mux_disconnect(gsm->ppp_dev, DLCI_PPP, K_FOREVER);
+			int err = uart_mux_disconnect(gsm->ppp_dev, DLCI_PPP, K_FOREVER);
+			if (err != 0) {
+				LOG_WRN("mux_disable(): UART mux disable returned %d for PPP device.", err);
+			}
 		}
 		if (gsm->control_dev) {
-			(void)uart_mux_disconnect(gsm->control_dev, DLCI_CONTROL, K_FOREVER);
+			int err = uart_mux_disconnect(gsm->control_dev, DLCI_CONTROL, K_FOREVER);
+			if (err != 0) {
+				LOG_WRN("mux_disable(): UART mux disable returned %d for CONTROL device.", err);
+			}
 		}
 		if (gsm->at_dev) {
 			uart_mux_disable(gsm->at_dev);

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1229,7 +1229,7 @@ static int mux_enable(struct gsm_modem *gsm)
 		/* Arbitrary delay for Quectel modems to initialize the CMUX,
 		 * without this the AT cmd will fail.
 		 */
-		(void)k_sleep(K_MSEC(50));
+		(void)k_sleep(GSM_CMD_AT_TIMEOUT);
 	} else {
 		/* Generic GSM modem */
 		ret = modem_cmd_send_nolock(&gsm->context.iface,

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -10,7 +10,7 @@ gitlint
 junit2html
 
 # helper for developers - code formatter
-clang-format>=1.13x
+clang-format>=1.13
 
 # Script used to build firmware images for NXP LPC MCUs.
 lpc_checksum


### PR DESCRIPTION
Adding error logging to the `gsm_ppp` and `gsm_mux` modules.  Also fixing a potential typo in `requirements-extras.txt` (that, for me, at least, causes the Zephyr setup script to fail.)